### PR TITLE
SDN-1492: Base network-tools on top of openshift-tools

### DIFF
--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -1,0 +1,25 @@
+#
+# This Dockerfile builds the development image of network-tools repo.
+#
+# NOTE:
+#
+# This image is only for development environment, so please DO NOT DEPLOY
+# this image in any production environment.
+#
+
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.15 AS builder
+WORKDIR /go/src/github.com/openshift/network-tools
+COPY . .
+
+FROM fedora:32
+COPY --from=builder /go/src/github.com/openshift/network-tools/debug-scripts/* /usr/bin/
+RUN yum -y --setopt=tsflags=nodocs install git go nginx jq tcpdump traceroute wireshark net-tools nmap-ncat pciutils strace numactl make && \
+    yum clean all && rm -rf /var/cache/* && \
+    curl https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.6.0/openshift-client-linux-4.6.0.tar.gz > /tmp/oc.tar.gz && \
+    tar xzvf /tmp/oc.tar.gz -C /usr/bin && \
+    rm /tmp/oc.tar.gz && \
+    # needed for ovnkube-trace
+    git clone https://github.com/openshift/ovn-kubernetes.git /usr/bin/ovn-kubernetes && \
+    pushd /usr/bin/ovn-kubernetes/go-controller && hack/build-go.sh cmd/ovnkube-trace && \
+    mv _output/go/bin/ovnkube-trace /usr/bin/ovnkube-trace && popd && \
+    rm -rf /usr/bin/ovn-kubernetes

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,8 +1,29 @@
+#
+# This Dockerfile is used in the release (CI) and art repos to build the image.
+#
+# NOTE: Keep this in sync with the main Dockerfile.
+#
 FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-1.15-openshift-4.7 AS builder
 WORKDIR /go/src/github.com/openshift/network-tools
 COPY . .
-ENV GO_PACKAGE github.com/openshift/network-tools
 
-FROM registry.svc.ci.openshift.org/ocp/4.7:base
-COPY --from=builder /go/src/github.com/openshift/network-tools/debug-scripts/ /usr/bin/debug-network-scripts/
-RUN yum -y install git go jq tcpdump nginx traceroute wireshark net-tools nmap-ncat pciutils strace numactl make; yum clean all
+# tools (openshift-tools) is based off cli
+FROM registry.svc.ci.openshift.org/ocp/4.7:tools
+COPY --from=builder /go/src/github.com/openshift/network-tools/debug-scripts/* /usr/bin/
+
+RUN INSTALL_PKGS="\
+    git \
+    go \
+    make \
+    nginx \
+    numactl \
+    traceroute \
+    wireshark \
+    " && \
+    yum -y install --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
+    yum clean all && rm -rf /var/cache/* && \
+    # needed for ovnkube-trace
+    git clone https://github.com/openshift/ovn-kubernetes.git /usr/bin/ovn-kubernetes && \
+    pushd /usr/bin/ovn-kubernetes/go-controller && hack/build-go.sh cmd/ovnkube-trace && \
+    mv _output/go/bin/ovnkube-trace /usr/bin/ovnkube-trace && popd && \
+    rm -rf /usr/bin/ovn-kubernetes

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,10 @@ IMAGE_REGISTRY := registry.svc.ci.openshift.org
 # $3 - Dockerfile path
 # $4 - context directory for image build
 $(call build-image,ocp-network-tools,$(IMAGE_REGISTRY)/ocp/4.7:ocp-network-tools, ./Dockerfile,.)
+
+# The "rhel" Dockerfile requires fiddling with RHEL subscriptions.
+# For testing purposes it's easier to just build a fedora-based image
+build-image-network-tools-test:
+	podman build --no-cache -f ./Dockerfile.fedora -t network-tools-test .
+
+.PHONY: build-image-network-tools-test


### PR DESCRIPTION
This patch also moves the installation of ovnkube-trace to the Dockerfile so that it is available in the image directly instead of having to install it in each script.

Users can invoke ovnkube-trace using:

```
oc adm network-tools -- ovnkube-trace --tcp --src <src-pod-name> --dst <dst-pod-name> --loglevel=5
```
once we integrate this image with oc client (this is WIP right now).

Note: I haven't changed the centos DockerFile to be based on openshift-tools. I think we can keep that image as testing image and have some level of freedom there.

/assign @rcarrillocruz 