### PR TITLE
Bug 1967933: Add proper directory path to which output will be saved

### DIFF
--- a/debug-scripts/sdn_cluster_and_node_info
+++ b/debug-scripts/sdn_cluster_and_node_info
@@ -166,16 +166,13 @@ Note: If you want the information only from a single node, you can provide that 
 }
 
 main () {
-    logdir=$(mktemp --tmpdir -d openshift-sdn-debug-XXXXXXXXX)
+    BASE_COLLECTION_PATH="network-tools"
+    logdir="$BASE_COLLECTION_PATH/openshift-sdn-cluster-and-node-info"
+    mkdir -p $logdir
     mkdir $logdir/meta
     mkdir $logdir/nodes
     cluster_info
     node_info "${node_name}" |& tee $logdir/log
-
-    dumpname=openshift-sdn-debug-$(date --iso-8601).tgz
-    (cd $logdir; tar -cf - --transform='s/^\./openshift-sdn-debug/' .) | gzip -c > $dumpname
-    echo ""
-    echo "Output is in $dumpname"
 }
 
 while getopts ":h" option; do


### PR DESCRIPTION
Make the base folder `network-tools` under which all logs can go under. Hence when using must-gather, one can specify the --src-dir from where the logs need to be copied from.