### PR TITLE
Bug 1967933: Add entry point for must-gather tooling

### DIFF
--- a/debug-scripts/gather
+++ b/debug-scripts/gather
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Invoke network-tools script. Entry point when using must-gather.
+/usr/bin/network-tools

--- a/debug-scripts/network-tools
+++ b/debug-scripts/network-tools
@@ -23,10 +23,10 @@ if [[ "$network_plugin" == "OVNKubernetes" ]] ; then
     ovn_ipsec_connectivity "$global_namespace"
 elif [[ "$network_plugin" == "OpenShiftSDN" ]] ; then
     # run scripts
-    sdn_cluster_and_node_info
-    # sdn_node_connectivity
     sdn_pod_to_pod_connectivity "$global_namespace"/"$client" "$global_namespace"/"$server"
     sdn_pod_to_svc_connectivity "$global_namespace"/"$client" "$global_namespace"/"$server"
+    sdn_cluster_and_node_info
+    # sdn_node_connectivity
 else
     echo "Unable to debug cluster networking. Only OpenShiftSDN and OVNKubernetes plugins are supported"
 fi

--- a/docs/contributor.md
+++ b/docs/contributor.md
@@ -19,7 +19,7 @@ This repository aims at providing debugging tools for:
 **NOTE :**  All the scripts can be executed using:
 
 ```
-    oc adm network-tools
+    oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest
 ```
 command. Note this is a [WIP] (https://github.com/openshift/oc/pull/709). See the user documentation for more information on how to run existing scripts against an OpenShift cluster.
 
@@ -45,7 +45,7 @@ Please follow the undermentioned instructions when adding a new script to the ne
 - The script should by default create the necessary resources to do the test if the user has not passed any arguments.
 - Each script should be both standalone and at the same time if invoked in the default mode, be compatible when running with the rest of the scripts.
 - Each message printed should fall under either `INFO` or `SUCCESS` or `FAILURE` categories.
-- Should test the functionality of the script with `oc adm network-tools --`. Make sure the script does not break the build and is well tested.
+- Should test the functionality of the script with `oc adm must-gather --`. Make sure the script does not break the build and is well tested.
 - Add documentation regarding what the script does to the user docs.
 - Even though this image can be accessed only by priviledges users/administrators, avoid security vulnerabilites.
 - Use discretion when commands need to be run from a network namespace. First preference would be to use the `oc debug node/xx` command. If there are too many commands to be run create a hostNetwork pod.

--- a/docs/user.md
+++ b/docs/user.md
@@ -10,7 +10,7 @@ OpenShift network-tools contains a set of:
 
 to debug the networking state of a cluster in real time. This tool is currently only supported (has been tested) from OCP4.8.
 
-**NOTE :**  The official supported way of running all scripts and tools are only through the `oc adm network-tools` utility. In certain unprecedented situations like when the api-server is down or networking is not up in the cluster, we might have to directly access the nodes in the cluster to figure out the root cause. In other situations, we may have to access the network namespace of the pod to run specific commands. Some of the scripts in this repository are written with such debugging situations in mind. Although the image is restricted to administrators and priviledges users, care must be taken when running such scripts locally on the cluster. Scripts must be double checked to ensure they do exactly what they intend to do.
+**NOTE :**  The official supported way of running all scripts and tools are only through the `oc adm must-gather` utility. In certain unprecedented situations like when the api-server is down or networking is not up in the cluster, we might have to directly access the nodes in the cluster to figure out the root cause. In other situations, we may have to access the network namespace of the pod to run specific commands. Some of the scripts in this repository are written with such debugging situations in mind. Although the image is restricted to administrators and priviledges users, care must be taken when running such scripts locally on the cluster. Scripts must be double checked to ensure they do exactly what they intend to do.
 
 # How is this different from must-gather?
 


### PR DESCRIPTION
This PR adds a gather script, that in turn calls the network-tools script. This is to maintain compatibility with must-gather tooling since the script entrypoint must be named as `gather`