### PR TITLE
Migrate existing scripts to network-tools

### DIFF
--- a/debug-scripts/local-scripts/ci-artifacts-get
+++ b/debug-scripts/local-scripts/ci-artifacts-get
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -euo pipefail
+source ./utils
+
+description() {
+  echo "Download ci prow job artifacts."
+}
+
+help () {
+  echo "Download ci prow job artifacts.
+
+ATTENTION! This is local command, can't be used with must-gather.
+ATTENTION! You need gsutil [https://cloud.google.com/storage/docs/gsutil_install] installed.
+
+Usage: $USAGE [-v] prowjob_url dest_path
+
+Examples:
+  $USAGE https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/26359/pull-ci-openshift-origin-master-e2e-aws-single-node/1422822145540493312 ./
+"
+}
+
+main() {
+  if [[ "$1" == "-v" ]]; then
+    output_ops=""
+    shift
+  else
+    output_ops=" >/dev/null 2>&1"
+  fi
+  gsurl="gs:/"
+  IFS=$'/' read -a arr <<< "$1"
+  for substr in "${arr[@]:5}" ; do
+    gsurl+="/$substr"
+  done
+  output_dir=$(ensure_output_dir "${2:-}")
+  echo "Downloading to $output_dir"
+  echo "It can take a couple of minutes, please wait"
+  eval "gsutil -m cp -r $gsurl $output_dir $output_ops"
+  echo DONE!
+}
+
+case "${1:-}" in
+  description) description ;;
+  -h|--help) help ;;
+  *) main "$@" ;;
+esac
+

--- a/debug-scripts/local-scripts/local-scripts-map
+++ b/debug-scripts/local-scripts/local-scripts-map
@@ -1,5 +1,7 @@
 #!/bin/bash
 
 declare -Ag INTERNAL_COMMANDS=(
+    ["ovn-pprof-forwarding"]="./local-scripts/ovn-pprof-forwarding"
+    ["ci-artifacts-get"]="./local-scripts/ci-artifacts-get"
     ["ovn-db-run-locally"]="./local-scripts/ovn-db-run-locally"
 )

--- a/debug-scripts/local-scripts/ovn-pprof-forwarding
+++ b/debug-scripts/local-scripts/ovn-pprof-forwarding
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -euo pipefail
+source ./utils
+
+function description() {
+  echo "Makes ovn pprof endpoints available on localhost"
+}
+
+function help() {
+  echo "This script enables port forwarding to make pprof endpoints for ovnkube containers available on localhost.
+It checks all connections every 60 sec and stops if at least one fails (it can happen if some pod was deleted).
+It this case just run this script again and it will use new pods.
+The output will show local port for every pod, then you can find pprof web interface at localhost:<pod port>/debug/pprof,
+and collect e.g. cpu profile with
+
+curl http://localhost:<pod port>/debug/pprof/profile?seconds=<duration>
+
+ATTENTION! This is local command, can't be used with must-gather.
+
+Usage: $USAGE
+
+Examples:
+  $USAGE
+"
+}
+
+MASTER_PORT=8100
+NODE_PORT=8200
+
+prepare () {
+  set -u pipefail
+
+  trap ctrl_c EXIT
+  IFS=" " read -r -a OVNKUBE_MASTER_PODS <<< "$(oc -n openshift-ovn-kubernetes get pods -l app=ovnkube-master -o=jsonpath='{.items[*].metadata.name}')"
+  for OVNKUBE_MASTER_POD in "${OVNKUBE_MASTER_PODS[@]}"; do
+      oc port-forward "${OVNKUBE_MASTER_POD}" ${MASTER_PORT}:29102 -n openshift-ovn-kubernetes > /dev/null &
+      PIDS+=($!)
+      echo $OVNKUBE_MASTER_POD pprof is on localhost:${MASTER_PORT}
+      ((MASTER_PORT+=1))
+  done
+  ((MASTER_PORT-=1))
+
+  IFS=" " read -r -a OVNKUBE_NODE_PODS <<< "$(oc -n openshift-ovn-kubernetes get pods -l app=ovnkube-node -o=jsonpath='{.items[*].metadata.name}')"
+  for OVNKUBE_NODE_POD in "${OVNKUBE_NODE_PODS[@]}"; do
+    oc port-forward "${OVNKUBE_NODE_POD}" ${NODE_PORT}:29103 -n openshift-ovn-kubernetes > /dev/null &
+      PIDS+=($!)
+      echo "$OVNKUBE_NODE_POD" pprof is on localhost:${NODE_PORT}
+      ((NODE_PORT+=1))
+  done
+  ((NODE_PORT-=1))
+  sleep 10
+  while true; do
+    for i in $(seq 8100 "$MASTER_PORT"); do
+    	nc -z 127.0.0.1 $i
+    done
+    for i in $(seq 8200 "$NODE_PORT"); do
+    	nc -z 127.0.0.1 $i
+    done
+    echo "connections are alive"
+    sleep 60
+  done
+}
+
+PIDS=()
+
+function ctrl_c() {
+    echo "Cleanup"
+    kill -KILL "${PIDS[@]}"
+}
+
+case "${1:-}" in
+  description) description ;;
+  -h|--help) help ;;
+  *) prepare "$@" ;;
+esac
+
+wait "${PIDS[@]}"

--- a/debug-scripts/network-tools
+++ b/debug-scripts/network-tools
@@ -14,11 +14,28 @@ cd "$scriptDir"
 
 source ./utils
 
+declare -A COMMANDS
+
+function add_commands() {
+  local -n command_table=$1
+  msg=$2
+  sorted=()
+  while IFS= read -rd '' key; do
+      sorted+=( "$key" )
+  done < <(printf '%s\0' "${!command_table[@]}" | sort -z)
+  for key in "${sorted[@]}"; do
+    local fn_name=${command_table[$key]}
+    description="$($fn_name "description")"
+    msg+="\t$key: $description\n"
+  done
+  for i in "${!command_table[@]}"; do
+    COMMANDS[$i]=${command_table[$i]}
+  done
+}
+
 function main() {
 
-    # add [command_name]=[script path] here to make a new script a part of network-tools
-    declare -A -x command_table=(
-        # ./test-networking scripts
+    declare -A -x network_test=(
         ["network-test"]="./test-networking/main"
         ["ovn-ipsec-connectivity"]="./test-networking/ovn_ipsec_connectivity"
         ["ovn-nic-firmware"]="./test-networking/ovn_nic_firmware"
@@ -29,33 +46,37 @@ function main() {
         ["sdn-pod-to-pod"]="./test-networking/sdn_pod_to_pod_connectivity"
         ["sdn-pod-to-svc"]="./test-networking/sdn_pod_to_svc_connectivity"
     )
-    if [[ -f "./local-scripts/local-scripts-map" ]]; then
-      source ./local-scripts/local-scripts-map
-      for i in "${!INTERNAL_COMMANDS[@]}"; do
-        command_table[$i]=${INTERNAL_COMMANDS[$i]}
-      done
-    fi
 
-    sorted=()
-    while IFS= read -rd '' key; do
-        sorted+=( "$key" )
-    done < <(printf '%s\0' "${!command_table[@]}" | sort -z)
+    # add [command_name]=[script path] here to make a new script a part of network-tools
+    declare -A -x other_commands=(
+        ["ovn-metrics-list"]="./scripts/ovn-metrics-list"
+    )
 
     msg="Usage: network-tools [command]
+"
+    msg+="
+Available commands
+"
+    add_commands other_commands "$msg"
 
-Available commands are:\n"
-    for key in "${sorted[@]}"; do
-      local fn_name=${command_table[$key]}
-      description="$($fn_name "description")"
-      msg+="\t$key: $description\n"
-    done
+     msg+="
+Network-test commands
+"
+    add_commands network_test "$msg"
+
+    if [[ -f "./local-scripts/local-scripts-map" ]]; then
+        source ./local-scripts/local-scripts-map
+        msg+="
+Local commands
+"
+        add_commands INTERNAL_COMMANDS "$msg"
+    fi
 
     if [[ $# -lt 1 ]]; then exit_with_help "$msg"; fi
-
     if [ "$1" == "-h" ]; then exit_with_help "$msg"; fi
 
     local command=${1}; shift
-    local fn_name=${command_table[$command]}
+    local fn_name=${COMMANDS[$command]}
 
     if [[ $fn_name == '' ]]; then exit_with_help "$msg"; fi
     export USAGE="network-tools ${command}"

--- a/debug-scripts/scripts/ovn-metrics-list
+++ b/debug-scripts/scripts/ovn-metrics-list
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+source ./utils
+
+description() {
+  echo "Collect OVN networking metrics: master, node, and ovn"
+}
+
+help () {
+  echo "This script collects OVN networking metrics: master, node, and ovn.
+If output folder is not specified, local path will be used.
+
+Usage: $USAGE [output_folder]
+
+Examples:
+  $USAGE
+  $USAGE /some/path/metrics
+
+  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE /must-gather
+"
+}
+
+main() {
+  dir=$(ensure_output_dir "${1:-}")
+  echo "Output directory ${dir}"
+  leader_host="$(get_ovnk_leader_node)"
+  master_leader_pod="$(get_ovnk_leader_pod)"
+  oc -n "$OVN_NAMESPACE" exec "$master_leader_pod" -c ovnkube-master -- curl "127.0.0.1:29102/metrics" > "$dir/$master_leader_pod-29102(master)"
+  node_pod="$(oc get pods -n $OVN_NAMESPACE --field-selector spec.nodeName=$leader_host -l app=ovnkube-node -o=jsonpath='{.items..metadata.name}')"
+  oc -n "$OVN_NAMESPACE" exec "$node_pod" -c ovnkube-node -- curl "127.0.0.1:29103/metrics" > "$dir/$node_pod-29103(node)"
+  oc -n "$OVN_NAMESPACE" exec "$node_pod" -c ovnkube-node -- curl "127.0.0.1:29105/metrics" > "$dir/$node_pod-29105(ovn)"
+}
+
+case "${1:-}" in
+  description) description ;;
+  -h|--help) help ;;
+  *) main "$@" ;;
+esac

--- a/docs/contributor.md
+++ b/docs/contributor.md
@@ -41,7 +41,7 @@ This is to maintain a minimum level of uniformity.
 where the scope reduces, e.g. if a script only works for ovn-k clusters, it should start with `ovn` and for openshift-sdn with `sdn`
   - Functions that are reused in more than one script should be added to the `utils`.
   - You can use `docs/script-template` as a template for a new script, make sure to update `description` and `help` functions
-  - Add command name <-> script path association in `network-tools` `command_table` or in `local-scripts/local-scripts-map`
+  - Add command name <-> script path association in `network-tools` `other_commands` or in `local-scripts/local-scripts-map`
     for local scripts.
   - Make sure your script can be run both locally and with `oc adm must-gather`
   - Make sure that `network-tools -h` and `network-tools <new script name> -h` shows your command and its help properly.

--- a/docs/generate-docs
+++ b/docs/generate-docs
@@ -8,9 +8,7 @@ print_help() {
     ./debug-scripts/network-tools -h | tail -n +4 |
       while IFS= read -r line
       do
-        #echo new line
-        #echo "$line"
-        command=$(echo $line | cut -d ":" -f 1)
+        command=$(echo $line | cut -s -d ":" -f 1)
         if [ ! -z "$command" ]; then
             echo "* \`network-tools $command\`"
             echo

--- a/docs/user.md
+++ b/docs/user.md
@@ -135,6 +135,21 @@ To copy a folder from network-tools container use `--source-dir '<container dir>
 # Available `network-tools` commands
 
 The following part of this file is auto-generated based on commands help.
+* `network-tools ovn-metrics-list`
+
+```
+This script collects OVN networking metrics: master, node, and ovn.
+If output folder is not specified, local path will be used.
+
+Usage: network-tools ovn-metrics-list [output_folder]
+
+Examples:
+  network-tools ovn-metrics-list
+  network-tools ovn-metrics-list /some/path/metrics
+
+  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-metrics-list /must-gather
+
+```
 * `network-tools network-test`
 
 ```
@@ -152,30 +167,6 @@ Examples:
   network-tools network-test
 
   oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools network-test
-
-```
-* `network-tools ovn-db-run-locally`
-
-```
-Run ovn-kubernetes container with ovn db restored from a given file.
-You will get interactive pseudo-TTY /bin/bash running in created container,
-after you end bash session (use Ctrl+D) container will be removed.
-
-The script will wait max 10 seconds for ovn db to start,
-if ovndb status is not active you will get warning message.
-
-ATTENTION! For clustered dbs: db will be converted from cluster to standalone format
-as this is the only way to run db from gathered data. Db UUIDs will be preserved.
-
-ATTENTION! This is local command, can't be used with must-gather.
-
-Usage: network-tools ovn-db-run-locally raw_db_file ovn_db_type [-e {docker,podman}]
-  raw_db_file: db file from must-gather
-  ovn_db_type: n for 'n' for northbound db, 's' for southbound db
-  -e {docker,podman}: choose container engine to use. Default is docker
-
-Examples:
-  network-tools ovn-db-run-locally ./must-gather.local.8470413320584178988/quay-io-npinaeva-must-gather-sha256-48826a17ba08cf1ef1e27a7b85fdff459efb8fc5807c26cdb525eecbfb0ec6a3/network_logs/leader_nbdb n
 
 ```
 * `network-tools ovn-ipsec-connectivity`
@@ -379,5 +370,62 @@ Examples:
   oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools sdn-pod-to-svc <src-pod-namespace>/<src-pod-name> <dst-svc-namespace>/<dst-svc-name>
   oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools sdn-pod-to-svc \"\" <dst-svc-namespace>/<dst-svc-name>
   oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools sdn-pod-to-svc <src-pod-namespace>/<src-pod-name>
+
+```
+* `network-tools ci-artifacts-get`
+
+```
+Download ci prow job artifacts.
+
+ATTENTION! This is local command, can't be used with must-gather.
+ATTENTION! You need gsutil [https://cloud.google.com/storage/docs/gsutil_install] installed.
+
+Usage: network-tools ci-artifacts-get [-v] prowjob_url dest_path
+
+Examples:
+  network-tools ci-artifacts-get https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/26359/pull-ci-openshift-origin-master-e2e-aws-single-node/1422822145540493312 ./
+
+```
+* `network-tools ovn-db-run-locally`
+
+```
+Run ovn-kubernetes container with ovn db restored from a given file.
+You will get interactive pseudo-TTY /bin/bash running in created container,
+after you end bash session (use Ctrl+D) container will be removed.
+
+The script will wait max 10 seconds for ovn db to start,
+if ovndb status is not active you will get warning message.
+
+ATTENTION! For clustered dbs: db will be converted from cluster to standalone format
+as this is the only way to run db from gathered data. Db UUIDs will be preserved.
+
+ATTENTION! This is local command, can't be used with must-gather.
+
+Usage: network-tools ovn-db-run-locally raw_db_file ovn_db_type [-e {docker,podman}]
+  raw_db_file: db file from must-gather
+  ovn_db_type: n for 'n' for northbound db, 's' for southbound db
+  -e {docker,podman}: choose container engine to use. Default is docker
+
+Examples:
+  network-tools ovn-db-run-locally ./must-gather.local.8470413320584178988/quay-io-npinaeva-must-gather-sha256-48826a17ba08cf1ef1e27a7b85fdff459efb8fc5807c26cdb525eecbfb0ec6a3/network_logs/leader_nbdb n
+
+```
+* `network-tools ovn-pprof-forwarding`
+
+```
+This script enables port forwarding to make pprof endpoints for ovnkube containers available on localhost.
+It checks all connections every 60 sec and stops if at least one fails (it can happen if some pod was deleted).
+It this case just run this script again and it will use new pods.
+The output will show local port for every pod, then you can find pprof web interface at localhost:<pod port>/debug/pprof,
+and collect e.g. cpu profile with
+
+curl http://localhost:<pod port>/debug/pprof/profile?seconds=<duration>
+
+ATTENTION! This is local command, can't be used with must-gather.
+
+Usage: network-tools ovn-pprof-forwarding
+
+Examples:
+  network-tools ovn-pprof-forwarding
 
 ```


### PR DESCRIPTION
Improve network-tools help: add sections for better readability.
Add 1 common script:
- ovn-metrics-list to collect ovn networking metrics: master, node,
and ovn

Add 2 local scripts:
- ci-artifacts-get to Download ci prow job artifacts
- ovn-pprof-forwarding to Make ovn pprof endpoints available on
localhost

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>