### PR TITLE
Implement new scripts to interact with ovn cluster

### DIFF
--- a/debug-scripts/local-scripts/ovn-pprof-forwarding
+++ b/debug-scripts/local-scripts/ovn-pprof-forwarding
@@ -9,7 +9,7 @@ function description() {
 function help() {
   echo "This script enables port forwarding to make pprof endpoints for ovnkube containers available on localhost.
 It checks all connections every 60 sec and stops if at least one fails (it can happen if some pod was deleted).
-It this case just run this script again and it will use new pods.
+In this case just run this script again and it will use new pods.
 The output will show local port for every pod, then you can find pprof web interface at localhost:<pod port>/debug/pprof,
 and collect e.g. cpu profile with
 

--- a/debug-scripts/network-tools
+++ b/debug-scripts/network-tools
@@ -50,6 +50,8 @@ function main() {
     # add [command_name]=[script path] here to make a new script a part of network-tools
     declare -A -x other_commands=(
         ["ovn-metrics-list"]="./scripts/ovn-metrics-list"
+        ["ovn-get"]="./scripts/ovn-get"
+        ["ovn-db-run-command"]="./scripts/ovn-db-run-command"
     )
 
     msg="Usage: network-tools [command]

--- a/debug-scripts/scripts/ovn-db-run-command
+++ b/debug-scripts/scripts/ovn-db-run-command
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -euo pipefail
+
+source ./utils
+
+description() {
+  echo "Run ovndb command like \"ovn-nbctl\" inside a leader pod"
+}
+
+help () {
+  echo "This script will find a leader pod (sbdb leader if \"sb\" substring is found in the command, otherwise nbdb leader),
+and then run command inside ovnkube-master container for the found pod.
+
+WARNING! All arguments and flags should be passed in the exact order as they listed below.
+
+Usage: $USAGE [-p <pod_name>] [-it] [command]
+
+Options:
+  -it:
+      to get interactive shell from the leader container use -it flag and empty command.
+      WARNING! Don't use -it flag when running network-tools with must-gather.
+
+  -p pod_name:
+      use given pod name to run command. Finding a leader can take up to 2*(number of master pods) seconds,
+      if you don't want to wait this additional time, add \"-p <db_leader_pod_name>\" parameter.
+      DB leader pod name will be printed for every call without \"-p\" option, you can use it for the next calls.
+
+Examples:
+  $USAGE ovn-nbctl show
+  $USAGE -p ovnkube-master-s7gdz ovn-nbctl show
+  $USAGE ovn-sbctl dump-flows
+  $USAGE -it
+  $USAGE -p ovnkube-master-s7gdz -it
+
+  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE ovn-nbctl show
+  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE -p ovnkube-master-s7gdz ovn-nbctl show
+  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE ovn-sbctl dump-flows
+"
+}
+
+main() {
+  if [[ "$1" == "-p" ]]; then
+    pod="$2"
+    shift 2
+  else
+    if [[ "$1" == *"sb"* ]]; then
+      DB="s"
+    else
+      DB="n"
+    fi
+    pod=$(get_ovndb_leader_pod $DB)
+    echo "Leader pod is $pod"
+  fi
+  if [[ "$1" == "-it" ]]; then
+    final_command="oc exec -tic ovnkube-master -n $OVN_NAMESPACE $pod -- /bin/bash"
+  else
+    command="bash -c \"${*:1}\""
+    if [ ! -z "${POD_NAME:-}" ]; then
+#     save output when run with must-gather
+      command+="|& tee /must-gather/output"
+    fi
+    final_command="oc exec -c ovnkube-master -n $OVN_NAMESPACE $pod -- $command"
+  fi
+  eval "$final_command"
+}
+
+case "${1:-}" in
+  description) description ;;
+  -h|--help) help ;;
+  *) main "$@" ;;
+esac

--- a/debug-scripts/scripts/ovn-get
+++ b/debug-scripts/scripts/ovn-get
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+source ./utils
+
+description() {
+  echo "Get/download ovn information from the cluster."
+}
+
+help () {
+  echo "This script can get different ovn-related information.
+
+Usage: $USAGE [object] [object options]
+
+Supported object:
+  leaders - prints ovnk master leader pod, nbdb and sbdb leader pods
+  dbs [output directory] - downloads nbdb and sbdb for every master pod. [output directory] is optional
+
+Examples:
+  $USAGE leaders
+  $USAGE dbs ./dbs
+
+  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE leaders
+  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE dbs /must-gather
+"
+}
+
+copy_ovn_dbs() {
+  dir=$(ensure_output_dir "${1:-}")
+  echo "Output directory ${dir}"
+#  next command will return an error, but this is expected, ignore error
+  set +e
+  output=$(oc cp --retries=5 2>&1)
+  if [[ "$output" == *"unknown flag"* ]]; then
+    flags=""
+  else
+    flags="--retries=5"
+  fi
+#  no more errors are expected
+  set -e
+  for ovnmaster in $(oc get pods -n "${OVN_NAMESPACE}" -l app=ovnkube-master -o=custom-columns=NAME:.metadata.name --no-headers); do
+    mkdir -p "${dir}"/"${ovnmaster}"
+    oc cp $flags openshift-ovn-kubernetes/"${ovnmaster}":/etc/ovn/ovnnb_db.db -c nbdb "${dir}"/"${ovnmaster}"/nbdb.db
+    oc cp $flags openshift-ovn-kubernetes/"${ovnmaster}":/etc/ovn/ovnsb_db.db -c sbdb "${dir}"/"${ovnmaster}"/sbdb.db
+    echo "$ovnmaster" done
+  done
+}
+
+get_dbs_leader() {
+  echo "ovn-k master leader $(get_ovnk_leader_pod)"
+  echo "nbdb leader $(get_ovndb_leader_pod n)"
+  echo "sbdb leader $(get_ovndb_leader_pod s)"
+}
+
+main() {
+  case $1 in
+    leaders) get_dbs_leader ;;
+    dbs) copy_ovn_dbs "${@:2}" ;;
+    *) echo "Unknown object \"$1\", use -h to see supported objects"; exit 1 ;;
+  esac
+}
+
+case "${1:-}" in
+  description) description ;;
+  -h|--help) help ;;
+  *) main "$@" ;;
+esac

--- a/debug-scripts/test-networking/main
+++ b/debug-scripts/test-networking/main
@@ -50,7 +50,7 @@ function main() {
       ./test-networking/sdn_pod_to_pod_connectivity "$global_namespace"/"$client" "$global_namespace"/"$server"
       ./test-networking/sdn_pod_to_svc_connectivity "$global_namespace"/"$client" "$global_namespace"/"$server"
       ./test-networking/sdn_cluster_and_node_info
-      if [ ! -z "$POD_NAME" ]; then
+      if [ -n "$POD_NAME" ]; then
 #        sdn_node_connectivity should not be run locally, $POD_NAME will be set when running with must-gather
         ./test-networking/sdn_node_connectivity
       fi

--- a/debug-scripts/utils
+++ b/debug-scripts/utils
@@ -40,7 +40,7 @@ get_ovndb_leader_pod () {
 
 ensure_output_dir () {
   pushd $NETWORK_TOOLS_INITIAL_DIR > /dev/null || exit 1
-  [ ! -z "$1" ] && dir="$1" && mkdir -p "$dir"
+  [ -n "$1" ] && dir="$1" && mkdir -p "$dir"
   [ -z "$1" ] && dir=$PWD
   cd $dir && pwd
   popd > /dev/null || exit 1
@@ -88,7 +88,7 @@ nsenter -n -t $ns_pid <command>
       echo
       echo "INFO: Running \"$command\" in the netns of pod $pod"
       FULL_COMMAND="nsenter -n -t $ns_pid $command"
-      if [ ! -z "$SLEEP" ]; then
+      if [ -n "$SLEEP" ]; then
         FULL_COMMAND="($FULL_COMMAND) $SLEEP"
       fi
 

--- a/docs/user.md
+++ b/docs/user.md
@@ -135,6 +135,57 @@ To copy a folder from network-tools container use `--source-dir '<container dir>
 # Available `network-tools` commands
 
 The following part of this file is auto-generated based on commands help.
+* `network-tools ovn-db-run-command`
+
+```
+This script will find a leader pod (sbdb leader if "sb" substring is found in the command, otherwise nbdb leader),
+and then run command inside ovnkube-master container for the found pod.
+
+WARNING! All arguments and flags should be passed in the exact order as they listed below.
+
+Usage: network-tools ovn-db-run-command [-p <pod_name>] [-it] [command]
+
+Options:
+  -it:
+      to get interactive shell from the leader container use -it flag and empty command.
+      WARNING! Don't use -it flag when running network-tools with must-gather.
+
+  -p pod_name:
+      use given pod name to run command. Finding a leader can take up to 2*(number of master pods) seconds,
+      if you don't want to wait this additional time, add "-p <db_leader_pod_name>" parameter.
+      DB leader pod name will be printed for every call without "-p" option, you can use it for the next calls.
+
+Examples:
+  network-tools ovn-db-run-command ovn-nbctl show
+  network-tools ovn-db-run-command -p ovnkube-master-s7gdz ovn-nbctl show
+  network-tools ovn-db-run-command ovn-sbctl dump-flows
+  network-tools ovn-db-run-command -it
+  network-tools ovn-db-run-command -p ovnkube-master-s7gdz -it
+
+  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-db-run-command ovn-nbctl show
+  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-db-run-command -p ovnkube-master-s7gdz ovn-nbctl show
+  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-db-run-command ovn-sbctl dump-flows
+
+```
+* `network-tools ovn-get`
+
+```
+This script can get different ovn-related information.
+
+Usage: network-tools ovn-get [object] [object options]
+
+Supported object:
+  leaders - prints ovnk master leader pod, nbdb and sbdb leader pods
+  dbs [output directory] - downloads nbdb and sbdb for every master pod. [output directory] is optional
+
+Examples:
+  network-tools ovn-get leaders
+  network-tools ovn-get dbs ./dbs
+
+  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-get leaders
+  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-get dbs /must-gather
+
+```
 * `network-tools ovn-metrics-list`
 
 ```
@@ -415,7 +466,7 @@ Examples:
 ```
 This script enables port forwarding to make pprof endpoints for ovnkube containers available on localhost.
 It checks all connections every 60 sec and stops if at least one fails (it can happen if some pod was deleted).
-It this case just run this script again and it will use new pods.
+In this case just run this script again and it will use new pods.
 The output will show local port for every pod, then you can find pprof web interface at localhost:<pod port>/debug/pprof,
 and collect e.g. cpu profile with
 


### PR DESCRIPTION
Add common scripts:
- ovn-db-run-command to run ovndb command like "ovn-nbctl" inside a
leader pod
- ovn-get to get/download ovn information from the cluster

Depends on https://github.com/openshift/network-tools/pull/65 (merged)