### PR TITLE
Add pod-run-netns-command script to run command from network-tools

### DIFF
--- a/debug-scripts/network-tools
+++ b/debug-scripts/network-tools
@@ -52,6 +52,7 @@ function main() {
         ["ovn-metrics-list"]="./scripts/ovn-metrics-list"
         ["ovn-get"]="./scripts/ovn-get"
         ["ovn-db-run-command"]="./scripts/ovn-db-run-command"
+        ["pod-run-netns-command"]="./scripts/pod-run-netns-command"
     )
 
     msg="Usage: network-tools [command]

--- a/debug-scripts/scripts/pod-run-netns-command
+++ b/debug-scripts/scripts/pod-run-netns-command
@@ -1,0 +1,124 @@
+#!/bin/bash
+set -euo pipefail
+
+source ./utils
+
+description() {
+  echo "Runs command from network-tools container within existing pod netnamespace"
+}
+
+help() {
+  echo "Runs command from network-tools container within existing pod netnamespace.
+First run for a node can take a little longer, since network-tools image needs to be downloaded.
+
+WARNING! All arguments and flags should be passed in the exact order as they listed below.
+
+Options:
+  -it:
+      To get interactive shell from network-tools container and run multiple commands use -it option.
+      It will create a debug pod and print nsenter command you need to use to run commands for pod netnamespace.
+
+      WARNING! Don't use -it flag when running network-tools with must-gather.
+
+  --preserve-pod, -pp:
+      Automatically downloading command output can be challenging. See below for explanation.
+      --preserve-pod option will save debug pod for 5 minutes, that should give you enough time to copy files
+      (see examples below)
+
+  --multiple-commands, -mc:
+      To run multiple commands, like \"command1; command2\" use this flag, and surround commands
+      with double quotes for local run (\"command\"), and with a combination of single and double quotes
+      for must-gather ('\"<command>\"').
+      See examples for more details
+
+  --no-substitution, -ns:
+      To preserve the literal meaning of the command you want run, prevent reserved words from being recognized as such,
+      and prevent parameter expansion and command substitution, use this flag and surround commands
+      with single quotes for local run ('command'), and with a sequence of quotes for must-gather run
+      (\"'\"'command'\"'\").
+      See examples for more details
+
+WARNING! Command will be executed from a debug pod, it means that copying files created as a result of
+your command execution may be challenging. You can forward command output to /must-gather (see examples below),
+but for commands like \"tcpdump -w pcap_file\" automatically downloading pcap_file is not possible.
+Use --preserve-pod option to save debug pod for 5 minutes, that should give you enough time to copy files (see
+examples below)
+
+WARNING! Don't forget to set timeout for long-running commands with must-gather,
+if you just Ctrl+C it won't cleanup must-gather resources.
+Must-gather has a default 10 min timeout for every command, if you need to change it use --timeout option.
+
+Usage: $USAGE [-it] [--preserve-pod, -pp] [--multiple-commands, -mc] [--no-substitution, -ns] namespace pod [command]
+
+Examples:
+  $USAGE default hello-pod nc -z -v <ip> <port>
+  $USAGE -it default hello-pod
+  $USAGE default hello-pod tcpdump
+  $USAGE default hello-pod timeout 10 tcpdump > <local_path>
+
+  To run multiple commands, use
+      $USAGE --multiple-commands default hello-pod \"<command1>; <command2>\"
+      Example:
+        $USAGE -mc default hello-pod \"ifconfig; ip a\"
+  To prevent parameter expansion, use
+      $USAGE --no-substitution default hello-pod '<command to run>'
+      Example:
+        $USAGE -ns default hello-pod 'i=0; ip a; i=\$(( \$i + 1 )); echo \$i'
+
+  If the command you are running generates a file instead of printing to stdout, you can download that file by preserving debug pod
+      [terminal1] $USAGE -pp default hello-pod timeout 10 tcpdump -w /tmp/tcpdump.pcap
+      # wait for DONE printed, note \"Starting pod/PODNAME\" log)
+      [terminal2] oc cp PODNAME:/tmp/tcpdump.pcap <local_path>
+      # you can Ctrl+C terminal1 when you don't need debug pod anymore)
+
+  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- \\
+      $USAGE default hello-pod nc -z -v <ip> <port>
+  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- \\
+      \"$USAGE default hello-pod ping 8.8.8.8 -c 5 > /must-gather/ping\"
+  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- \\
+      \"$USAGE default hello-pod timeout 30 tcpdump > /must-gather/tcpdump_output\"
+
+  To run multiple commands, use
+      oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- \\
+          $USAGE --multiple-commands default hello-pod '\"<command1>; <command2>\"'
+      Example:
+          oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- \\
+              $USAGE -mc default hello-pod '\"ifconfig; ip a\"'
+  To prevent parameter expansion, use
+      oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- \\
+          $USAGE --no-substitution default hello-pod \"'\"'<command to run>'\"'\"
+      Example:
+          oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- \\
+              $USAGE -ns default hello-pod \"'\"'i=0; ip a; i=\$(( \$i + 1 )); echo \$i'\"'\"
+
+  If the command you are running generates a file instead of output, you can download that file by preserving debug pod
+      [terminal1] oc adm must-gather --image=$NETWORK_TOOLS_IMAGE --  \\
+          $USAGE -pp default hello-pod timeout 10 tcpdump -w /tmp/tcpdump.pcap
+
+      # wait for
+      # [must-gather-fj4hp] POD 2022-07-29T15:23:03.977676789Z DONE
+      # printed, note log
+      # [must-gather-fj4hp] POD 2022-07-29T15:22:53.001812898Z Starting pod/PODNAME ...
+      # also note
+      # [must-gather      ] OUT namespace/MG_NAMESPACE created)
+      # use these names to compose cp command:
+
+      [terminal2] oc cp -n MG_NAMESPACE PODNAME:/tmp/tcpdump.pcap <local_path>
+      # DON'T Ctrl+C terminal1 - wait for must-gather to finish by itself
+"
+}
+
+main() {
+  if [[ "$1" == "-it" ]]; then
+    shift
+    run_command_inside_pod_network_namespace_with_network_tools $1 $2
+  else
+    run_command_inside_pod_network_namespace_with_network_tools "$@"
+  fi
+}
+
+case "${1:-}" in
+  description) description ;;
+  -h|--help) help ;;
+  *) main "$@" ;;
+esac

--- a/debug-scripts/utils
+++ b/debug-scripts/utils
@@ -64,13 +64,26 @@ get_ns_pid() {
 
 run_command_inside_pod_network_namespace_with_network_tools() {
     SLEEP=""
-    if [[ "$1" == "--preserve-pod" ]]; then
+    if [[ "$1" == "--preserve-pod" || "$1" == "-pp" ]]; then
        SLEEP="; echo DONE; sleep 300"
        shift
     fi
+    left_braces=""
+    right_braces=""
+    if [[ "$1" == "--multiple-commands" || "$1" == "-mc" ]]; then
+      shift
+      left_braces="\""
+      right_braces="\""
+    fi
+    if [[ "$1" == "--no-substitution" || "$1" == "-ns" ]]; then
+      shift
+      left_braces="'"
+      right_braces="'"
+    fi
     local namespace="${1}"
     local pod="${2}"
-    local command="${*:3}"
+
+    local command="$left_braces${*:3}$right_braces"
 
     node_name="$(get_pod_node "$namespace" "$pod")"
     ns_pid="$(get_ns_pid "$namespace" "$pod")"
@@ -86,12 +99,11 @@ nsenter -n -t $ns_pid <command>
       oc debug node/"$node_name" --image=$NETWORK_TOOLS_IMAGE
     else
       echo
-      echo "INFO: Running \"$command\" in the netns of pod $pod"
-      FULL_COMMAND="nsenter -n -t $ns_pid $command"
+      echo "INFO: Running $command in the netns of pod $pod"
+      FULL_COMMAND="nsenter -n -t $ns_pid /bin/bash -c $command"
       if [ -n "$SLEEP" ]; then
         FULL_COMMAND="($FULL_COMMAND) $SLEEP"
       fi
-
       oc debug node/"$node_name" --image=$NETWORK_TOOLS_IMAGE -- bash -c "$FULL_COMMAND"
     fi
 }

--- a/docs/user.md
+++ b/docs/user.md
@@ -201,6 +201,108 @@ Examples:
   oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-metrics-list /must-gather
 
 ```
+* `network-tools pod-run-netns-command`
+
+```
+Runs command from network-tools container within existing pod netnamespace.
+First run for a node can take a little longer, since network-tools image needs to be downloaded.
+
+WARNING! All arguments and flags should be passed in the exact order as they listed below.
+
+Options:
+  -it:
+      To get interactive shell from network-tools container and run multiple commands use -it option.
+      It will create a debug pod and print nsenter command you need to use to run commands for pod netnamespace.
+
+      WARNING! Don't use -it flag when running network-tools with must-gather.
+
+  --preserve-pod, -pp:
+      Automatically downloading command output can be challenging. See below for explanation.
+      --preserve-pod option will save debug pod for 5 minutes, that should give you enough time to copy files
+      (see examples below)
+
+  --multiple-commands, -mc:
+      To run multiple commands, like "command1; command2" use this flag, and surround commands
+      with double quotes for local run ("command"), and with a combination of single and double quotes
+      for must-gather ('"<command>"').
+      See examples for more details
+
+  --no-substitution, -ns:
+      To preserve the literal meaning of the command you want run, prevent reserved words from being recognized as such,
+      and prevent parameter expansion and command substitution, use this flag and surround commands
+      with single quotes for local run ('command'), and with a sequence of quotes for must-gather run
+      ("'"'command'"'").
+      See examples for more details
+
+WARNING! Command will be executed from a debug pod, it means that copying files created as a result of
+your command execution may be challenging. You can forward command output to /must-gather (see examples below),
+but for commands like "tcpdump -w pcap_file" automatically downloading pcap_file is not possible.
+Use --preserve-pod option to save debug pod for 5 minutes, that should give you enough time to copy files (see
+examples below)
+
+WARNING! Don't forget to set timeout for long-running commands with must-gather,
+if you just Ctrl+C it won't cleanup must-gather resources.
+Must-gather has a default 10 min timeout for every command, if you need to change it use --timeout option.
+
+Usage: network-tools pod-run-netns-command [-it] [-pp] [-mc] [-ns] namespace pod [command]
+
+Examples:
+  network-tools pod-run-netns-command default hello-pod nc -z -v <ip> <port>
+  network-tools pod-run-netns-command -it default hello-pod
+  network-tools pod-run-netns-command default hello-pod tcpdump
+  network-tools pod-run-netns-command default hello-pod timeout 10 tcpdump > <local_path>
+
+  To run multiple commands, use
+      network-tools pod-run-netns-command --multiple-commands default hello-pod "<command1>; <command2>"
+      Example:
+        network-tools pod-run-netns-command -mc default hello-pod "ifconfig; ip a"
+  To prevent parameter expansion, use
+      network-tools pod-run-netns-command --no-substitution default hello-pod '<command to run>'
+      Example:
+        network-tools pod-run-netns-command -ns default hello-pod 'i=0; ip a; i=$(( $i + 1 )); echo $i'
+
+  If the command you are running generates a file instead of printing to stdout, you can download that file by preserving debug pod
+      [terminal1] network-tools pod-run-netns-command --preserve-pod default hello-pod timeout 10 tcpdump -w /tmp/tcpdump.pcap
+      # wait for DONE printed, note "Starting pod/PODNAME" log)
+      [terminal2] oc cp PODNAME:/tmp/tcpdump.pcap <local_path>
+      # you can Ctrl+C terminal1 when you don't need debug pod anymore)
+
+  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- \
+      network-tools pod-run-netns-command default hello-pod nc -z -v <ip> <port>
+  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- \
+      "network-tools pod-run-netns-command default hello-pod ping 8.8.8.8 -c 5 > /must-gather/ping"
+  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- \
+      "network-tools pod-run-netns-command default hello-pod timeout 30 tcpdump > /must-gather/tcpdump_output"
+
+  To run multiple commands, use
+      oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- \
+          network-tools pod-run-netns-command --multiple-commands default hello-pod '"<command1>; <command2>"'
+      Example:
+          oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- \
+              network-tools pod-run-netns-command -mc default hello-pod '"ifconfig; ip a"'
+  To prevent parameter expansion, use
+      oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- \
+          network-tools pod-run-netns-command --no-substitution default hello-pod "'"'<command to run>'"'"
+      Example:
+          oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- \
+              network-tools pod-run-netns-command -ns default hello-pod "'"'i=0; ip a; i=$(( $i + 1 )); echo $i'"'"
+
+  If the command you are running generates a file instead of output, you can download that file by preserving debug pod
+      [terminal1] oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest --  \
+          network-tools pod-run-netns-command --preserve-pod default hello-pod timeout 10 tcpdump -w /tmp/tcpdump.pcap
+
+      # wait for
+      # [must-gather-fj4hp] POD 2022-07-29T15:23:03.977676789Z DONE
+      # printed, note log
+      # [must-gather-fj4hp] POD 2022-07-29T15:22:53.001812898Z Starting pod/PODNAME ...
+      # also note
+      # [must-gather      ] OUT namespace/MG_NAMESPACE created)
+      # use these names to compose cp command:
+
+      [terminal2] oc cp -n MG_NAMESPACE PODNAME:/tmp/tcpdump.pcap <local_path>
+      # DON'T Ctrl+C terminal1 - wait for must-gather to finish by itself
+
+```
 * `network-tools network-test`
 
 ```


### PR DESCRIPTION
container within existing pod netnamespace.
This command has multiple options and examples, please check
if they all make sense and work properly.

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>