### PR TITLE
Minor fixed found during demo preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@ network-tools
 =============
 
 `network-tools` is a collection of tools for debugging OpenShift cluster network issues.
-It will contain both debugging scripts (described in the next section) and useful tools that can be used
-by network engineers and openshift operators to debug and diagnose issues.
+It contains both debugging scripts (described in the next section) and useful tools to get
+information from the cluster. This repo is supposed to be used by network engineers and 
+support to debug and diagnose issues. Customers can also be advised to use commands from this 
+image to help get required information.
 
 ## How to use
 
@@ -40,3 +42,6 @@ are not copied to the image. But these scripts are available for local use (`net
 * Please see [contributor docs](https://github.com/openshift/network-tools/blob/master/docs/contributor.md) for more information regarding the scope of this repository and how to contribute.
 * Users can go to [user docs](https://github.com/openshift/network-tools/blob/master/docs/user.md) for information on how to leverage the tools and scripts shipped by this image.
 
+## Contacts
+
+For all questions reach out to [#forum-sdn](https://coreos.slack.com/archives/CDCP2LA9L) Slack channel, Openshift SDN team is maintaining this repo.

--- a/debug-scripts/local-scripts/ovn-db-run-locally
+++ b/debug-scripts/local-scripts/ovn-db-run-locally
@@ -33,6 +33,7 @@ clean_up () {
   echo "CLEANUP"
   $CONTAINER_ENGINE stop $CONTAINER
   $CONTAINER_ENGINE rm $CONTAINER
+  exit 0
 }
 
 main() {
@@ -42,7 +43,7 @@ main() {
 
   CONTAINER_ENGINE="${3:-docker}"
   DB_TYPE=$2
-  DB_FILE=$1
+  DB_FILE=$(get_full_path "$1")
 
   CONTAINER=$($CONTAINER_ENGINE run -t -d --entrypoint /bin/bash quay.io/openshift/origin-ovn-kubernetes:latest)
   # cleanup if container is successfully created
@@ -64,11 +65,11 @@ main() {
   # wait for ovndb status to become running, max waiting time 10 sec
 
   i=1
-  until $CONTAINER_ENGINE exec $CONTAINER /bin/bash -c "ovn-${DB_TYPE}bctl show" > /dev/null; do
+  until $CONTAINER_ENGINE exec $CONTAINER /bin/bash -c "ovn-${DB_TYPE}bctl show" > /dev/null 2>&1; do
     sleep 1
     ((i++)) && ((i==10)) && echo "\"ovn-${DB_TYPE}bctl show\" return non-zero code, check error messages" && break
   done
-  $CONTAINER_ENGINE  exec -it $CONTAINER /bin/bash
+  $CONTAINER_ENGINE exec -it $CONTAINER /bin/bash
 }
 
 case "${1:-}" in

--- a/debug-scripts/utils
+++ b/debug-scripts/utils
@@ -68,17 +68,20 @@ run_command_inside_pod_network_namespace_with_network_tools() {
        SLEEP="; echo DONE; sleep 300"
        shift
     fi
+    with_bash=""
     left_braces=""
     right_braces=""
     if [[ "$1" == "--multiple-commands" || "$1" == "-mc" ]]; then
       shift
       left_braces="\""
       right_braces="\""
+      with_bash="bash -c "
     fi
     if [[ "$1" == "--no-substitution" || "$1" == "-ns" ]]; then
       shift
       left_braces="'"
       right_braces="'"
+      with_bash="bash -c "
     fi
     local namespace="${1}"
     local pod="${2}"
@@ -100,7 +103,7 @@ nsenter -n -t $ns_pid <command>
     else
       echo
       echo "INFO: Running $command in the netns of pod $pod"
-      FULL_COMMAND="nsenter -n -t $ns_pid /bin/bash -c $command"
+      FULL_COMMAND="nsenter -n -t $ns_pid $with_bash $command"
       if [ -n "$SLEEP" ]; then
         FULL_COMMAND="($FULL_COMMAND) $SLEEP"
       fi
@@ -108,3 +111,11 @@ nsenter -n -t $ns_pid <command>
     fi
 }
 
+get_full_path() {
+  if [[ "$1" = /* ]]; then
+    echo "$1"
+  else
+    relative_path=$1
+    readlink -e "$NETWORK_TOOLS_INITIAL_DIR/$relative_path" || { echo "Provided path $relative_path doesn't exist" 1>&2; exit 1; }
+  fi
+}


### PR DESCRIPTION
Use get_full_path for file inputs to make sure we convert relative path correctly.
Only use bash -c with braced commands for netnamespace
Add contacts in README

Signed-off-by: Nadia Pinaeva <npinaeva@redhat.com>