### PR TITLE
Rename subcomponent to ensure bugs are assigned correctly

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -23,4 +23,7 @@ approvers:
   - tssurya
   - astoycos
   - npinaeva
-component: "Networking"
+
+# Bugzilla info; "ovn-kubernetes" is wrong but there is no "generic networking" subcomponent
+component: Networking
+subcomponent: ovn-kubernetes


### PR DESCRIPTION
Though network-tools doesn't have a subcomponent, it still should be assigned one to have bugs successfully come into the networking/subcomponent.

Signed-off-by: Surya Seetharaman <suryaseetharaman.9@gmail.com>