### PR TITLE
OCPBUGS-7106: Get OVN-Kubernetes leader identity from the lease

### DIFF
--- a/debug-scripts/utils
+++ b/debug-scripts/utils
@@ -7,8 +7,13 @@ SDN_PLUGIN="OpenShiftSDN"
 NETWORK_TOOLS_IMAGE="quay.io/openshift/origin-network-tools:latest"
 
 get_ovnk_leader_node () {
-  oc get cm -n ${OVN_NAMESPACE} ovn-kubernetes-master -o jsonpath='{.metadata.annotations.control-plane\.alpha\.kubernetes\.io\/leader}' | \
-    grep -Po '"holderIdentity":.*?[^\\]"' | awk -F':' '{print $2}' | sed 's/"//g'
+  n=$(oc -n ${OVN_NAMESPACE} get lease ovn-kubernetes-master -o jsonpath='{.spec.holderIdentity}' 2> /dev/null)
+  if [ -z "$n" ]; then
+    oc get cm -n ${OVN_NAMESPACE} ovn-kubernetes-master -o jsonpath='{.metadata.annotations.control-plane\.alpha\.kubernetes\.io\/leader}' | \
+      grep -Po '"holderIdentity":.*?[^\\]"' | awk -F':' '{print $2}' | sed 's/"//g'
+  else
+    echo "$n"
+  fi
 }
 
 get_ovnk_leader_pod () {


### PR DESCRIPTION
Starting in Kubernetes v1.26, OVN-Kubernetes uses the lease API to publish the leader identity. 
To keep backwards compatibility fallback to a configmap.

Signed-off-by: Patryk Diak <pdiak@redhat.com>