### PR TITLE
Dockerfile: move to RHEL9 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.19-openshift-4.13 AS builder
 WORKDIR /go/src/github.com/openshift/network-tools
 COPY . .
 


### PR DESCRIPTION
It's inconsistent that the base image is RHEL8 but that it also copies ovnkube-trace from the RHEL9-based ovn-kubernetes image. The two images should use the same base (eg, RHEL9).