### PR TITLE
ovn-db-run-locally: gracefully handle non-clustered dbs

### DIFF
--- a/debug-scripts/local-scripts/ovn-db-run-locally
+++ b/debug-scripts/local-scripts/ovn-db-run-locally
@@ -53,14 +53,13 @@ main() {
   COPIED_DB="/etc/ovn/copied_db"
   $CONTAINER_ENGINE cp "${DB_FILE}" $CONTAINER:$COPIED_DB
   FINAL_DB="/etc/ovn/ovn${DB_TYPE}b_db.db"
-  $CONTAINER_ENGINE exec $CONTAINER /bin/bash -c "ovsdb-tool db-is-clustered ${COPIED_DB}"
-  if [ $? -eq 0 ]; then
+  $CONTAINER_ENGINE exec $CONTAINER /bin/bash -c "ovsdb-tool db-is-clustered ${COPIED_DB}" && {
     echo "CLUSTERED DB, convert to standalone"
     $CONTAINER_ENGINE exec $CONTAINER /bin/bash -c "ovsdb-tool cluster-to-standalone ${FINAL_DB} ${COPIED_DB}"
-  else
+  } || {
     echo "NOT CLUSTERED DB"
     $CONTAINER_ENGINE exec $CONTAINER /bin/bash -c "cp ${COPIED_DB} ${FINAL_DB}"
-  fi
+  }
   $CONTAINER_ENGINE exec $CONTAINER /usr/share/ovn/scripts/ovn-ctl run_${DB_TYPE}b_ovsdb &
   # wait for ovndb status to become running, max waiting time 10 sec
 


### PR DESCRIPTION
This commit improves the checking of the dbs that are not clustered. When db is not clustered, the check actually returned a failure, which would cause the script failure to be caught and cause the container to exit. Then, the user would never make it to the bash prompt.
