### PR TITLE
update Dockerfile base to rhel-9 from rhel-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.14 AS builder
 WORKDIR /go/src/github.com/openshift/network-tools
 COPY . .
 


### PR DESCRIPTION
this will provide wireshark v3 instead of v2