### PR TITLE
SDN-3904: Update scripts in network-tools to reflect the changes in IC model

### DIFF
--- a/debug-scripts/local-scripts/ovn-pprof-forwarding
+++ b/debug-scripts/local-scripts/ovn-pprof-forwarding
@@ -13,7 +13,7 @@ In this case just run this script again and it will use new pods.
 The output will show local port for every pod, then you can find pprof web interface at localhost:<pod port>/debug/pprof,
 and collect e.g. cpu profile with
 
-curl http://localhost:<pod port>/debug/pprof/profile?seconds=<duration>
+curl -L http://localhost:<pod port>/debug/pprof/profile?seconds=<duration>
 
 ATTENTION! This is local command, can't be used with must-gather.
 
@@ -24,33 +24,44 @@ Examples:
 "
 }
 
-MASTER_PORT=8100
+if ! command -v nc &> /dev/null; then
+  echo "nc is not installed. Exiting." >&2
+  exit 1
+fi
+
+CM_OR_MASTER_PORT=8100
 NODE_PORT=8200
+
+if [ $(get_ovn_mode) == "ovn-ic" ]; then
+  PPROF_CM_OR_MASTER_PORT=29108
+else
+  PPROF_CM_OR_MASTER_PORT=29102
+fi
 
 prepare () {
   set -u pipefail
 
   trap ctrl_c EXIT
-  IFS=" " read -r -a OVNKUBE_MASTER_PODS <<< "$(oc -n openshift-ovn-kubernetes get pods -l app=ovnkube-master -o=jsonpath='{.items[*].metadata.name}')"
+  IFS=" " read -r -a OVNKUBE_MASTER_PODS <<< "$(oc -n openshift-ovn-kubernetes get pods -l 'app in (ovnkube-master,ovnkube-control-plane)' -o=jsonpath='{.items[*].metadata.name}')"
   for OVNKUBE_MASTER_POD in "${OVNKUBE_MASTER_PODS[@]}"; do
-      oc port-forward "${OVNKUBE_MASTER_POD}" ${MASTER_PORT}:29102 -n openshift-ovn-kubernetes > /dev/null &
+      oc port-forward "${OVNKUBE_MASTER_POD}" ${CM_OR_MASTER_PORT}:${PPROF_CM_OR_MASTER_PORT} -n openshift-ovn-kubernetes > /dev/null &
       PIDS+=($!)
-      echo $OVNKUBE_MASTER_POD pprof is on localhost:${MASTER_PORT}
-      ((MASTER_PORT+=1))
+      echo $OVNKUBE_MASTER_POD pprof is on localhost:${CM_OR_MASTER_PORT}
+      ((CM_OR_MASTER_PORT+=1))
   done
-  ((MASTER_PORT-=1))
+  ((CM_OR_MASTER_PORT-=1))
 
   IFS=" " read -r -a OVNKUBE_NODE_PODS <<< "$(oc -n openshift-ovn-kubernetes get pods -l app=ovnkube-node -o=jsonpath='{.items[*].metadata.name}')"
   for OVNKUBE_NODE_POD in "${OVNKUBE_NODE_PODS[@]}"; do
     oc port-forward "${OVNKUBE_NODE_POD}" ${NODE_PORT}:29103 -n openshift-ovn-kubernetes > /dev/null &
-      PIDS+=($!)
-      echo "$OVNKUBE_NODE_POD" pprof is on localhost:${NODE_PORT}
-      ((NODE_PORT+=1))
+    PIDS+=($!)
+    echo "$OVNKUBE_NODE_POD" pprof is on localhost:${NODE_PORT}
+    ((NODE_PORT+=1))
   done
   ((NODE_PORT-=1))
   sleep 10
   while true; do
-    for i in $(seq 8100 "$MASTER_PORT"); do
+    for i in $(seq 8100 "$CM_OR_MASTER_PORT"); do
     	nc -z 127.0.0.1 $i
     done
     for i in $(seq 8200 "$NODE_PORT"); do

--- a/debug-scripts/scripts/ovn-db-run-command
+++ b/debug-scripts/scripts/ovn-db-run-command
@@ -4,37 +4,40 @@ set -euo pipefail
 source ./utils
 
 description() {
-  echo "Run ovndb command like \"ovn-nbctl\" inside a leader pod"
+  echo "Run ovndb command like \"ovn-nbctl\" inside a pod"
 }
 
 help () {
-  echo "This script will find a leader pod (sbdb leader if \"sb\" substring is found in the command, otherwise nbdb leader),
-and then run command inside ovnkube-master container for the found pod.
+  echo "In non-ovn-ic (legacy) clusters, this script will find a leader pod (sbdb leader
+if \"sb\" substring is found in the command, otherwise nbdb leader), and then run command
+inside ovnkube-master container for the found pod.
 
 WARNING! All arguments and flags should be passed in the exact order as they listed below.
+WARNING! With ovn-ic, the -p flag should be provided since all node pods have a db.
 
 Usage: $USAGE [-p <pod_name>] [-it] [command]
 
 Options:
   -it:
-      to get interactive shell from the leader container use -it flag and empty command.
+      to get interactive shell from the selected container use -it flag and empty command.
       WARNING! Don't use -it flag when running network-tools with must-gather.
 
   -p pod_name:
-      use given pod name to run command. Finding a leader can take up to 2*(number of master pods) seconds,
-      if you don't want to wait this additional time, add \"-p <db_leader_pod_name>\" parameter.
-      DB leader pod name will be printed for every call without \"-p\" option, you can use it for the next calls.
+      use given pod name to run command. In non-ovn-ic custers, finding a leader can take up to
+      2*(number of master pods) seconds, if you don't want to wait this additional time, add
+      \"-p <db_selected_pod_name>\" parameter.
+      Selected pod name will be printed for every call without \"-p\" option, you can use it for the next calls.
+
 
 Examples:
   $USAGE ovn-nbctl show
-  $USAGE -p ovnkube-master-s7gdz ovn-nbctl show
+  $USAGE -p ovnkube-node-cdv6q ovn-nbctl show
   $USAGE ovn-sbctl dump-flows
   $USAGE -it
-  $USAGE -p ovnkube-master-s7gdz -it
+  $USAGE -p ovnkube-node-twkpx -it
 
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE ovn-nbctl show
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE -p ovnkube-master-s7gdz ovn-nbctl show
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE ovn-sbctl dump-flows
+  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE -p ovnkube-node-cdv6q ovn-nbctl show
+  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE -p ovnkube-node-twkpx ovn-sbctl dump-flows
 "
 }
 
@@ -43,23 +46,30 @@ main() {
     pod="$2"
     shift 2
   else
-    if [[ "$1" == *"sb"* ]]; then
-      DB="s"
+    if [ $(get_ovn_mode) == "ovn-ic" ]; then
+      pod=$(oc -n ${OVN_NAMESPACE} get pods -l app=ovnkube-node -o=jsonpath='{.items[0].metadata.name}')
+      echo "Pod not provided while using ovn-ic cluster: Randomly using pod $pod"
     else
-      DB="n"
+      # Legacy mode suport: pod parameter is not necessary on 4.13 and older releases
+      if [[ "$1" == *"sb"* ]]; then
+        DB="s"
+      else
+        DB="n"
+      fi
+      pod=$(get_ovndb_leader_pod $DB)
+      echo "Leader pod is $pod"
     fi
-    pod=$(get_ovndb_leader_pod $DB)
-    echo "Leader pod is $pod"
   fi
+  OVN_CONTAINER="$(get_ovn_controller_container_name)"
   if [[ "$1" == "-it" ]]; then
-    final_command="oc exec -tic ovnkube-master -n $OVN_NAMESPACE $pod -- /bin/bash"
+    final_command="oc exec -tic $OVN_CONTAINER -n $OVN_NAMESPACE $pod -- /bin/bash"
   else
     command="bash -c \"${*:1}\""
     if [ -n "${POD_NAME:-}" ]; then
 #     save output when run with must-gather
       command+="|& tee /must-gather/output"
     fi
-    final_command="oc exec -c ovnkube-master -n $OVN_NAMESPACE $pod -- $command"
+    final_command="oc exec -c $OVN_CONTAINER -n $OVN_NAMESPACE $pod -- $command"
   fi
   eval "$final_command"
 }

--- a/debug-scripts/scripts/ovn-get
+++ b/debug-scripts/scripts/ovn-get
@@ -15,17 +15,65 @@ Supported object:
   leaders - prints ovnk master leader pod, nbdb and sbdb leader pods
   dbs [output directory] - downloads nbdb and sbdb for every master pod. [output directory] is optional for local usage
       and should be omitted for must-gather
+  mode - prints out whether ovn cluster is running as single zone (legacy) or multi-zone (ovn-ic)
 
 Examples:
   $USAGE leaders
   $USAGE dbs ./dbs
+  $USAGE mode
 
   oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE leaders
   oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE dbs
+  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE mode
 "
 }
 
 copy_ovn_dbs() {
+  if [ $(get_ovn_mode) == "ovn-legacy" ]; then
+    copy_ovn_dbs_legacy_mode $@
+  else
+    copy_ovn_dbs_interconnect_mode $@
+  fi
+}
+
+function copy_ovn_dbs_interconnect_mode {
+  if [ -n "${POD_NAME:-}" ]; then
+#    script is run with must-gather
+    dir="/must-gather"
+  else
+    dir=$(ensure_output_dir "${1:-}")
+  fi
+  echo "Output directory ${dir}"
+#  next command will return an error, but this is expected, ignore error
+  set +e
+  output=$(oc cp --retries=5 2>&1)
+  if [[ "$output" == *"unknown flag"* ]]; then
+    flags=""
+  else
+    flags="--retries=5"
+  fi
+#  no more errors are expected
+  set -e
+  OVNKUBE_CONTROLLER_PODS=($(oc -n openshift-ovn-kubernetes get pods -l app=ovnkube-node -o=jsonpath='{.items[*].metadata.name}'))
+  # collect dbs from each node
+  for DB in "n" "s"; do
+    if [ "$DB" = "n" ]; then
+      DB_NAME="OVN_Northbound"
+      CONTAINER="nbdb"
+    else
+      DB_NAME="OVN_Southbound"
+      CONTAINER="sbdb"
+    fi
+    for OVNKUBE_CONTROLLER_POD in "${OVNKUBE_CONTROLLER_PODS[@]}"; do
+      echo "Gathering "${DB_NAME}" from "${OVNKUBE_CONTROLLER_POD}
+      OUTPUT=$(oc cp $flags openshift-ovn-kubernetes/"${OVNKUBE_CONTROLLER_POD}":/etc/ovn/ovn"${DB}"b_db.db -c "${CONTAINER}" \
+               "${dir}/${OVNKUBE_CONTROLLER_POD}_${DB}bdb" 2>&1)
+      [ "$OUTPUT" == "tar: Removing leading \`/' from member names" ] || echo $OUTPUT
+    done
+  done
+}
+
+copy_ovn_dbs_legacy_mode() {
   if [ -n "${POD_NAME:-}" ]; then
 #    script is run with must-gather
     dir="/must-gather"
@@ -57,10 +105,20 @@ get_dbs_leader() {
   echo "sbdb leader $(get_ovndb_leader_pod s)"
 }
 
+show_ovn_mode() {
+  echo -n cluster is running in
+  if [ $(get_ovn_mode) == "ovn-legacy" ]; then
+    echo " single-zone (legacy)"
+  else
+    echo " multi-zone (ovn-interconnect / ovn-ic)"
+  fi
+}
+
 main() {
   case $1 in
     leaders) get_dbs_leader ;;
     dbs) copy_ovn_dbs "${@:2}" ;;
+    mode) show_ovn_mode ;;
     *) echo "Unknown object \"$1\", use -h to see supported objects"; exit 1 ;;
   esac
 }

--- a/debug-scripts/scripts/ovn-metrics-list
+++ b/debug-scripts/scripts/ovn-metrics-list
@@ -4,17 +4,20 @@ set -euo pipefail
 source ./utils
 
 description() {
-  echo "Collect OVN networking metrics: master, node, and ovn"
+  echo "Collect OVN networking metrics: control-plane, node, and ovn"
 }
 
 help () {
-  echo "This script collects OVN networking metrics: master, node, and ovn.
+  echo "This script collects OVN networking metrics: control-plane, node, and ovn.
+Metrics will be collected from leader host, unless a node is provided.
 If output folder is not specified, local path will be used.
 
-Usage: $USAGE [output_folder]
+Usage: $USAGE [-n node] [output_folder]
 
 Examples:
   $USAGE
+  $USAGE -n node_name
+  $USAGE --node node_name /some/path/metrics
   $USAGE /some/path/metrics
 
   oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE /must-gather
@@ -24,13 +27,37 @@ Examples:
 main() {
   dir=$(ensure_output_dir "${1:-}")
   echo "Output directory ${dir}"
-  leader_host="$(get_ovnk_leader_node)"
-  master_leader_pod="$(get_ovnk_leader_pod)"
-  oc -n "$OVN_NAMESPACE" exec "$master_leader_pod" -c ovnkube-master -- curl "127.0.0.1:29102/metrics" > "$dir/$master_leader_pod-29102(master)"
-  node_pod="$(oc get pods -n $OVN_NAMESPACE --field-selector spec.nodeName=$leader_host -l app=ovnkube-node -o=jsonpath='{.items..metadata.name}')"
-  oc -n "$OVN_NAMESPACE" exec "$node_pod" -c ovnkube-node -- curl "127.0.0.1:29103/metrics" > "$dir/$node_pod-29103(node)"
-  oc -n "$OVN_NAMESPACE" exec "$node_pod" -c ovnkube-node -- curl "127.0.0.1:29105/metrics" > "$dir/$node_pod-29105(ovn)"
+  if [ -n "${node_name}" ]; then
+    # Validate node name provided
+    oc get node $node_name -o name 2>/dev/null || { echo "Can't get node ${node_name}" 1>&2; exit 1; }
+  else
+    node_name="$(get_ovnk_leader_node)"
+  fi
+  # Find out if there is a control/master pod running in the provided node. Leader/control-plane nodes will have one.
+  node_control_pod="$(oc get pods -n $OVN_NAMESPACE --field-selector spec.nodeName=${node_name} -l 'app in (ovnkube-master,ovnkube-control-plane)' -o=jsonpath='{.items..metadata.name}')"
+  node_pod="$(oc get pods -n $OVN_NAMESPACE --field-selector spec.nodeName=$node_name -l app=ovnkube-node -o=jsonpath='{.items..metadata.name}')"
+  OVN_CTL_CONTAINER="$(get_ovn_controller_container_name)"
+  if [ $(get_ovn_mode) == "ovn-ic" ]; then
+    [ -n "${node_control_pod}" ] && \
+      oc -n "$OVN_NAMESPACE" exec "$node_control_pod" -c ovnkube-cluster-manager -- curl "127.0.0.1:29108/metrics" > "$dir/$node_control_pod-29108(control-plane)"
+    oc -n "$OVN_NAMESPACE" exec "$node_pod" -c "$OVN_CTL_CONTAINER" -- curl "127.0.0.1:29103/metrics" > "$dir/$node_pod-29103(node)"
+    oc -n "$OVN_NAMESPACE" exec "$node_pod" -c "$OVN_CTL_CONTAINER" -- curl "127.0.0.1:29105/metrics" > "$dir/$node_pod-29105(ovn)"
+  else
+    [ -n "${node_control_pod}" ] && \
+      oc -n "$OVN_NAMESPACE" exec "$node_control_pod" -c "$OVN_CTL_CONTAINER" -- curl "127.0.0.1:29102/metrics" > "$dir/$node_control_pod-29102(master)"
+    oc -n "$OVN_NAMESPACE" exec "$node_pod" -c ovnkube-node -- curl "127.0.0.1:29103/metrics" > "$dir/$node_pod-29103(node)"
+    oc -n "$OVN_NAMESPACE" exec "$node_pod" -c ovnkube-node -- curl "127.0.0.1:29105/metrics" > "$dir/$node_pod-29105(ovn)"
+  fi
 }
+
+node_name=""
+case "${1:-}" in
+  -n|--node)
+    node_name="$2"
+    shift 2
+    ;;
+  *) ;;
+esac
 
 case "${1:-}" in
   description) description ;;

--- a/debug-scripts/utils
+++ b/debug-scripts/utils
@@ -12,20 +12,48 @@ get_ovnk_leader_node () {
     oc get cm -n ${OVN_NAMESPACE} ovn-kubernetes-master -o jsonpath='{.metadata.annotations.control-plane\.alpha\.kubernetes\.io\/leader}' | \
       grep -Po '"holderIdentity":.*?[^\\]"' | awk -F':' '{print $2}' | sed 's/"//g'
   else
-    echo "$n"
+    # in 4.14 and newer releases, the holderIdentidy is a pod, not the host. try extracting host from pod, if that is the case
+    pod_host=$(oc -n ${OVN_NAMESPACE} get pod $n -o jsonpath='{.spec.nodeName}' 2> /dev/null)
+    if [ -n "$pod_host" ]; then
+      echo "$pod_host"
+    else
+      echo "$n"
+    fi
   fi
 }
 
 get_ovnk_leader_pod () {
   leader_host=$(get_ovnk_leader_node)
   [ -z "$leader_host" ] && { echo "not found"; exit 1; }
-  master_leader_pod="$(oc get pods -n $OVN_NAMESPACE --field-selector spec.nodeName=${leader_host} -l app=ovnkube-master -o=jsonpath='{.items..metadata.name}' \
+  # label for leader pod in 4.14 and newer releases is ovnkube-control-plane
+  master_leader_pod="$(oc get pods -n $OVN_NAMESPACE --field-selector spec.nodeName=${leader_host} -l 'app in (ovnkube-master,ovnkube-control-plane)' -o=jsonpath='{.items..metadata.name}' \
   || { echo "Can't get master leader pod on the node ${leader_host}" 1>&2; echo "not found"; exit 1; })"
   echo "${master_leader_pod}"
 }
 
 get_network_plugin () {
   oc get networks.config.openshift.io cluster -o 'jsonpath={.spec.networkType}'
+}
+
+function get_ovn_mode {
+  sample_node=$(oc get no -o jsonpath='{.items[0].metadata.name}')
+  sample_node_zone=$(oc get node "${sample_node}" -o jsonpath='{.metadata.annotations.k8s\.ovn\.org/zone-name}')
+  if [ "${sample_node}" = "${sample_node_zone}" ]; then
+    echo "ovn-ic"
+  else
+    echo "ovn-legacy"
+  fi
+}
+
+function get_ovn_controller_container_name {
+  OVN_CONTAINER="ovnkube-controller"
+  [ $(get_ovn_mode) == "ovn-ic" ] || OVN_CONTAINER="ovnkube-master"
+  echo ${OVN_CONTAINER}
+}
+
+get_ovndb_pods () {
+  NODE_PODS=$(oc -n ${OVN_NAMESPACE} get pods -l app=ovnkube-node -o=jsonpath='{.items[*].metadata.name}' || { echo "Can't get ovnkube-node pods" 1>&2; exit 1; })
+  echo ${NODE_PODS}
 }
 
 get_ovndb_leader_pod () {
@@ -35,14 +63,19 @@ get_ovndb_leader_pod () {
     s) DB="s"; DB_NAME="OVN_Southbound" ;;
     *) echo "Unrecognized ovn db type ${1}, choose one of n, s"; exit 1 ;;
   esac
-  MASTER_PODS=$(oc -n ${OVN_NAMESPACE} get pods -l app=ovnkube-master -o=jsonpath='{.items[*].metadata.name}' || { echo "Can't get ovnkube-master pods" 1>&2; exit 1; })
-  for MASTER_POD in ${MASTER_PODS}; do
-    RAFT_ROLE=$(oc exec -n ${OVN_NAMESPACE} "${MASTER_POD}" -c ${DB}bdb -- bash -c "ovn-appctl -t /var/run/ovn/ovn${DB}b_db.ctl cluster/status ${DB_NAME} 2>&1 | grep \"^Role\"")
-    if echo "${RAFT_ROLE}" | grep -q -i leader; then
-      LEADER=$MASTER_POD
-      break
-    fi
-  done
+  # in ovn-ic, there is no ovndb_leader
+  if [ $(get_ovn_mode) == "ovn-legacy" ]; then
+    MASTER_PODS=$(oc -n ${OVN_NAMESPACE} get pods -l app=ovnkube-master -o=jsonpath='{.items[*].metadata.name}' || { echo "Can't get ovnkube-master pods" 1>&2; exit 1; })
+    for MASTER_POD in ${MASTER_PODS}; do
+      RAFT_ROLE=$(oc exec -n ${OVN_NAMESPACE} "${MASTER_POD}" -c ${DB}bdb -- bash -c "ovn-appctl -t /var/run/ovn/ovn${DB}b_db.ctl cluster/status ${DB_NAME} 2>&1 | grep \"^Role\"")
+      if echo "${RAFT_ROLE}" | grep -q -i leader; then
+        LEADER=$MASTER_POD
+        break
+      fi
+    done
+  else
+    LEADER="not applicable in ovn-ic mode"
+  fi
   echo "${LEADER}"
 }
 


### PR DESCRIPTION
Support scripts on network-tools side on IC mode.

TODO: 
- [x] docs/user.md
- [ ] create image?

Reported-at: https://issues.redhat.com/browse/SDN-3904

Slides 74+ in https://docs.google.com/presentation/d/1HXhY0cK5wiO-xRrbKdATpZ3xRCQPXJy_WRY-Ys9IjcM/edit?usp=sharing




## New command:

```
$ network-tools ovn-get mode
cluster is running in multi-zone (ovn-interconnect / ovn-ic)
```

On non ovn-ic cluster, you will see:

```
$ network-tools ovn-get mode
cluster is running in single-zone (legacy)
```

## Enhancements to existing commands:

```
$ network-tools ovn-get leaders
ovn-k master leader ovnkube-control-plane-XYZ
nbdb leader not applicable in ovn-ic mode
sbdb leader not applicable in ovn-ic mode
```

With ovn-ic, the ovn dbs are present on every ovnkube-node pod.
That is fundamentally different from previous releases, where ovn dbs would be in the master pods.

-- 

```
$ network-tools ovn-get dbs ./dbs
Output directory /home/vagrant/dev/network-tools.git/dbs
Gathering OVN_Northbound from ovnkube-node-ABC
Gathering OVN_Northbound from ovnkube-node-DEF
…
Gathering OVN_Southbound from ovnkube-node-ABC
Gathering OVN_Southbound from ovnkube-node-DEF
…
```

Dbs will be collected from all the nodes.

-- 

```
$ network-tools ovn-db-run-command -p ovnkube-node-XYZ ovn-nbctl show
$ network-tools ovn-db-run-command -it
Pod not provided while using ovn-ic cluster: Randomly using pod ovnkube-node-XYZ
[root@ip-10-0-52-80 ~]# ovn-nbctl -V
ovn-nbctl 23.09.90
Open vSwitch Library 3.2.1
DB Schema 7.1.0
```

Specify ovnkube-node pod (via the -p flag) in order to use the corresponding ovn database in ovn-ic cluster:

In order to map pods to nodes, use the following command as reference:

```
$ oc -n openshift-ovn-kubernetes get pod -l=app=ovnkube-node \
 -o='custom-columns=NAME:.metadata.name,NODE:.spec.nodeName'  \
 --sort-by=.spec.nodeName
```

--

```
$ network-tools ovn-metrics-list -n master-1 ./metrics
```

Use the optional -n parameter to specify the node that metrics will be collected from. If node has a controller pod, it will collect metrics from that pod as well. Otherwise, metrics from ovnkube-node will be obtained.


