### PR TITLE
Update docs to use image-streams instead of quay image

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ You can also create a symlink for your convenience to just use `network-tools`
 ### On the cluster
 
 You can use almost all the same scripts on the cluster via network-tools image, to run one command you can use
-`oc adm must-gather --image quay.io/openshift/origin-network-tools:latest -- network-tools -h`
+`oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools -h`
 
 WARNING! `must-gather` doesn't allow interactive input, don't use interactive options with must-gather.
+WARNING! For clusters older than 4.13, use `--image quay.io/openshift/origin-network-tools:latest` instead of `--image-streams`
 
 For more examples and options check [user docs](https://github.com/openshift/network-tools/blob/master/docs/user.md)
 

--- a/debug-scripts/scripts/ovn-db-run-command
+++ b/debug-scripts/scripts/ovn-db-run-command
@@ -36,8 +36,8 @@ Examples:
   $USAGE -it
   $USAGE -p ovnkube-node-twkpx -it
 
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE -p ovnkube-node-cdv6q ovn-nbctl show
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE -p ovnkube-node-twkpx ovn-sbctl dump-flows
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE -p ovnkube-node-cdv6q ovn-nbctl show
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE -p ovnkube-node-twkpx ovn-sbctl dump-flows
 "
 }
 

--- a/debug-scripts/scripts/ovn-get
+++ b/debug-scripts/scripts/ovn-get
@@ -22,9 +22,9 @@ Examples:
   $USAGE dbs ./dbs
   $USAGE mode
 
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE leaders
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE dbs
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE mode
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE leaders
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE dbs
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE mode
 "
 }
 

--- a/debug-scripts/scripts/ovn-metrics-list
+++ b/debug-scripts/scripts/ovn-metrics-list
@@ -20,7 +20,7 @@ Examples:
   $USAGE --node node_name /some/path/metrics
   $USAGE /some/path/metrics
 
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE /must-gather
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE /must-gather
 "
 }
 

--- a/debug-scripts/scripts/pod-run-netns-command
+++ b/debug-scripts/scripts/pod-run-netns-command
@@ -71,28 +71,28 @@ Examples:
       [terminal2] oc cp PODNAME:/tmp/tcpdump.pcap <local_path>
       # you can Ctrl+C terminal1 when you don't need debug pod anymore)
 
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- \\
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- \\
       $USAGE default hello-pod nc -z -v <ip> <port>
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- \\
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- \\
       \"$USAGE default hello-pod ping 8.8.8.8 -c 5 > /must-gather/ping\"
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- \\
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- \\
       \"$USAGE default hello-pod timeout 30 tcpdump > /must-gather/tcpdump_output\"
 
   To run multiple commands, use
-      oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- \\
+      oc adm must-gather $NETWORK_TOOLS_IMAGE -- \\
           $USAGE --multiple-commands default hello-pod '\"<command1>; <command2>\"'
       Example:
-          oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- \\
+          oc adm must-gather $NETWORK_TOOLS_IMAGE -- \\
               $USAGE -mc default hello-pod '\"ifconfig; ip a\"'
   To prevent parameter expansion, use
-      oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- \\
+      oc adm must-gather $NETWORK_TOOLS_IMAGE -- \\
           $USAGE --no-substitution default hello-pod \"'\"'<command to run>'\"'\"
       Example:
-          oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- \\
+          oc adm must-gather $NETWORK_TOOLS_IMAGE -- \\
               $USAGE -ns default hello-pod \"'\"'i=0; ip a; i=\$(( \$i + 1 )); echo \$i'\"'\"
 
   If the command you are running generates a file instead of output, you can download that file by preserving debug pod
-      [terminal1] oc adm must-gather --image=$NETWORK_TOOLS_IMAGE --  \\
+      [terminal1] oc adm must-gather $NETWORK_TOOLS_IMAGE --  \\
           $USAGE -pp default hello-pod timeout 10 tcpdump -w /tmp/tcpdump.pcap
 
       # wait for

--- a/debug-scripts/test-networking/main
+++ b/debug-scripts/test-networking/main
@@ -22,7 +22,7 @@ Usage: $USAGE
 Examples:
   $USAGE
 
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE
 "
 }
 

--- a/debug-scripts/test-networking/ovn_ipsec_connectivity
+++ b/debug-scripts/test-networking/ovn_ipsec_connectivity
@@ -108,7 +108,7 @@ Usage: $USAGE
 Examples:
   $USAGE
 
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE
 "
 }
 

--- a/debug-scripts/test-networking/ovn_nic_firmware
+++ b/debug-scripts/test-networking/ovn_nic_firmware
@@ -33,7 +33,7 @@ Usage: $USAGE
 Examples:
   $USAGE
 
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE
 "
 }
 

--- a/debug-scripts/test-networking/ovn_pod_to_pod_connectivity
+++ b/debug-scripts/test-networking/ovn_pod_to_pod_connectivity
@@ -78,11 +78,11 @@ Examples:
   $USAGE \"\" <dst-pod-namespace>/<dst-pod-name>
   $USAGE <src-pod-namespace>/<src-pod-name>
 
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE <src-node-name> <dst-node-name>
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE <src-pod-namespace>/<src-pod-name> <dst-pod-namespace>/<dst-pod-name>
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE \\\"\\\" <dst-pod-namespace>/<dst-pod-name>
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE <src-pod-namespace>/<src-pod-name>
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE <src-node-name> <dst-node-name>
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE <src-pod-namespace>/<src-pod-name> <dst-pod-namespace>/<dst-pod-name>
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE \\\"\\\" <dst-pod-namespace>/<dst-pod-name>
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE <src-pod-namespace>/<src-pod-name>
 "
 }
 

--- a/debug-scripts/test-networking/ovn_pod_to_svc_connectivity
+++ b/debug-scripts/test-networking/ovn_pod_to_svc_connectivity
@@ -83,11 +83,11 @@ Examples:
   $USAGE \"\" <dst-pod-namespace>/<dst-pod-name>
   $USAGE <src-pod-namespace>/<src-pod-name>
 
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE <src-node-name> <dst-node-name>
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE <src-pod-namespace>/<src-pod-name> <dst-svc-namespace>/<dst-svc-name>
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE \\\"\\\" <dst-svc-namespace>/<dst-svc-name>
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE <src-pod-namespace>/<src-pod-name>
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE <src-node-name> <dst-node-name>
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE <src-pod-namespace>/<src-pod-name> <dst-svc-namespace>/<dst-svc-name>
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE \\\"\\\" <dst-svc-namespace>/<dst-svc-name>
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE <src-pod-namespace>/<src-pod-name>
 "
 }
 

--- a/debug-scripts/test-networking/sdn_cluster_and_node_info
+++ b/debug-scripts/test-networking/sdn_cluster_and_node_info
@@ -167,7 +167,7 @@ Usage: $USAGE [node_name]
 Examples:
   $USAGE
 
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE
 "
 }
 

--- a/debug-scripts/test-networking/sdn_node_connectivity
+++ b/debug-scripts/test-networking/sdn_node_connectivity
@@ -53,10 +53,10 @@ help()
     echo "This script checks the node connectivity on an Openshift SDN cluster from a must-gather pod.
 ATTENTION! Can't be run locally
 
-Usage: oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE
+Usage: oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE
 
 Examples:
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE
 "
 }
 

--- a/debug-scripts/test-networking/sdn_pod_to_pod_connectivity
+++ b/debug-scripts/test-networking/sdn_pod_to_pod_connectivity
@@ -65,11 +65,11 @@ Examples:
   $USAGE \"\" <dst-pod-namespace>/<dst-pod-name>
   $USAGE <src-pod-namespace>/<src-pod-name>
 
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE <src-node-name> <dst-node-name>
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE <src-pod-namespace>/<src-pod-name> <dst-pod-namespace>/<dst-pod-name>
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE \\\"\\\" <dst-pod-namespace>/<dst-pod-name>
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE <src-pod-namespace>/<src-pod-name>
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE <src-node-name> <dst-node-name>
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE <src-pod-namespace>/<src-pod-name> <dst-pod-namespace>/<dst-pod-name>
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE \\\"\\\" <dst-pod-namespace>/<dst-pod-name>
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE <src-pod-namespace>/<src-pod-name>
 "
 }
 

--- a/debug-scripts/test-networking/sdn_pod_to_svc_connectivity
+++ b/debug-scripts/test-networking/sdn_pod_to_svc_connectivity
@@ -120,11 +120,11 @@ Examples:
   $USAGE \"\" <dst-pod-namespace>/<dst-pod-name>
   $USAGE <src-pod-namespace>/<src-pod-name>
 
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE <src-node-name> <dst-node-name>
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE <src-pod-namespace>/<src-pod-name> <dst-svc-namespace>/<dst-svc-name>
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE \\\"\\\" <dst-svc-namespace>/<dst-svc-name>
-  oc adm must-gather --image=$NETWORK_TOOLS_IMAGE -- $USAGE <src-pod-namespace>/<src-pod-name>
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE <src-node-name> <dst-node-name>
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE <src-pod-namespace>/<src-pod-name> <dst-svc-namespace>/<dst-svc-name>
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE \\\"\\\" <dst-svc-namespace>/<dst-svc-name>
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE <src-pod-namespace>/<src-pod-name>
 "
 }
 

--- a/debug-scripts/utils
+++ b/debug-scripts/utils
@@ -4,7 +4,7 @@ set -eo pipefail
 OVN_NAMESPACE="openshift-ovn-kubernetes"
 OVN_PLUGIN="OVNKubernetes"
 SDN_PLUGIN="OpenShiftSDN"
-NETWORK_TOOLS_IMAGE="quay.io/openshift/origin-network-tools:latest"
+NETWORK_TOOLS_IMAGE="--image-stream openshift/network-tools:latest"
 
 get_ovnk_leader_node () {
   n=$(oc -n ${OVN_NAMESPACE} get lease ovn-kubernetes-master -o jsonpath='{.spec.holderIdentity}' 2> /dev/null)
@@ -149,7 +149,7 @@ To run commands for pod netnamespace use
 
 nsenter -n -t $ns_pid <command>
 "
-      oc debug node/"$node_name" --image=$NETWORK_TOOLS_IMAGE
+      oc debug node/"$node_name" $NETWORK_TOOLS_IMAGE
     else
       echo
       echo "INFO: Running $command in the netns of pod $pod"
@@ -157,7 +157,7 @@ nsenter -n -t $ns_pid <command>
       if [ -n "$SLEEP" ]; then
         FULL_COMMAND="($FULL_COMMAND) $SLEEP"
       fi
-      oc debug node/"$node_name" --image=$NETWORK_TOOLS_IMAGE -- bash -c "$FULL_COMMAND"
+      oc debug node/"$node_name" $NETWORK_TOOLS_IMAGE -- bash -c "$FULL_COMMAND"
     fi
 }
 

--- a/docs/user.md
+++ b/docs/user.md
@@ -36,7 +36,7 @@ You can also create a symlink for your convenience to just use `network-tools`
 ### On the cluster
 
 You can use almost all the same scripts on the cluster via network-tools image, to run one command you can use
-`oc adm must-gather --image quay.io/openshift/origin-network-tools:latest -- network-tools -h`
+`oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools -h`
 
 WARNING! `must-gather` doesn't allow interactive input, don't use interactive options with must-gather.
 
@@ -45,10 +45,10 @@ Running `network-tools` on a cluster is different from local run:
 2. Everything from the `/must-gather` folder will be copied at the end of command execution, therefore
    1. to forward command output to a file use
 
-      `oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- "network-tools <command> > /must-gather/<filename>"`
+      `oc adm must-gather --image-stream openshift/network-tools:latest -- "network-tools <command> > /must-gather/<filename>"`
    2. for commands that accept output folder as parameter, use `/must-gather`
    
-`oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools -h` will show all available 
+`oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools -h` will show all available 
 commands on the cluster.
 
 To run script that are not included in the `network-tools -h` call them directly via
@@ -70,7 +70,7 @@ The image is based on oc https://github.com/openshift/oc/blob/master/images/tool
 and also includes all the tools from this Dockerfile.
 
 You can run custom command from `network-tools` container by
-`oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- <cmd>`
+`oc adm must-gather --image-stream openshift/network-tools:latest -- <cmd>`
 
 **WARNING!** `must-gather` has a timeout of 10 minutes, and shouldn't be interrupted with Ctrl+C in order for
 `must-gather` to properly clean up its resources. 
@@ -80,10 +80,9 @@ To make sure commands like tcpdump stop in N seconds you can use `timeout N <com
 N seconds.
 
 ```
-oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- timeout 5 ping 8.8.8.8
+oc adm must-gather --image-stream openshift/network-tools:latest -- timeout 5 ping 8.8.8.8
 
 output:
-[must-gather      ] OUT pod for plug-in image quay.io/openshift/origin-network-tools:latest created
 [must-gather-9j484] POD 2021-11-08T10:31:18.945125411Z PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
 [must-gather-9j484] POD 2021-11-08T10:31:18.945125411Z 64 bytes from 8.8.8.8: icmp_seq=1 ttl=49 time=3.54 ms
 [must-gather-9j484] POD 2021-11-08T10:31:19.945091109Z 64 bytes from 8.8.8.8: icmp_seq=2 ttl=49 time=1.76 ms
@@ -105,7 +104,7 @@ To copy a folder from network-tools container use `--source-dir '<container dir>
 ## Examples
 * Run tcpdump on all master nodes
   ```
-  oc adm must-gather --source-dir '/tmp/tcpdump/' --image quay.io/openshift/origin-network-tools:latest 
+  oc adm must-gather --source-dir '/tmp/tcpdump/' --image-stream openshift/network-tools:latest 
   --node-selector 'kubernetes.io/os=linux,node-role.kubernetes.io/master' --host-network -- 
   timeout 30 tcpdump -i any -w /tmp/tcpdump/\$POD_NAME-%Y-%m-%dT%H:%M:%S.pcap -W 1 -G 300
   ```
@@ -121,11 +120,10 @@ To copy a folder from network-tools container use `--source-dir '<container dir>
   ```
   To run a trace between them:
    ```
-    oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- ovnkube-trace -dst-namespace default -dst multitool-756669cf4f-bhx64 -src-namespace default -src multitool-756669cf4f-6bftt -tcp -loglevel 5
-    [must-gather      ] OUT Using must-gather plugin-in image: quay.io/openshift/origin-network-tools:latest
+    oc adm must-gather --image-stream openshift/network-tools:latest -- ovnkube-trace -dst-namespace default -dst multitool-756669cf4f-bhx64 -src-namespace default -src multitool-756669cf4f-6bftt -tcp -loglevel 5
     [must-gather      ] OUT namespace/openshift-must-gather-zm2mj created
     [must-gather      ] OUT clusterrolebinding.rbac.authorization.k8s.io/must-gather-4gcvh created
-    [must-gather      ] OUT pod for plug-in image quay.io/openshift/origin-network-tools:latest created
+    [must-gather      ] OUT pod for plug-in image quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:8750c821da621a846fd92b52cee7d6d42c3035790e026d30e5589f7b811a2bb4 created
     [must-gather-gq2ln] POD I0217 13:39:39.939788       8 ovs.go:95] Maximum command line arguments set to: 191102
     [must-gather-gq2ln] POD I0217 13:39:39.940114       8 ovnkube-trace.go:517] Log level set to: 5
     <snipped>.....
@@ -166,8 +164,8 @@ Examples:
   network-tools ovn-db-run-command -it
   network-tools ovn-db-run-command -p ovnkube-node-twkpx -it
 
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-db-run-command -p ovnkube-node-cdv6q ovn-nbctl show
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-db-run-command -p ovnkube-node-twkpx ovn-sbctl dump-flows
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools ovn-db-run-command -p ovnkube-node-cdv6q ovn-nbctl show
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools ovn-db-run-command -p ovnkube-node-twkpx ovn-sbctl dump-flows
 
 ```
 * `network-tools ovn-get`
@@ -188,9 +186,9 @@ Examples:
   network-tools ovn-get dbs ./dbs
   network-tools ovn-get mode
 
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-get leaders
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-get dbs
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-get mode
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools ovn-get leaders
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools ovn-get dbs
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools ovn-get mode
 
 ```
 * `network-tools ovn-metrics-list`
@@ -208,7 +206,7 @@ Examples:
   network-tools ovn-metrics-list --node node_name /some/path/metrics
   network-tools ovn-metrics-list /some/path/metrics
 
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-metrics-list /must-gather
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools ovn-metrics-list /must-gather
 
 ```
 * `network-tools pod-run-netns-command`
@@ -277,28 +275,28 @@ Examples:
       [terminal2] oc cp PODNAME:/tmp/tcpdump.pcap <local_path>
       # you can Ctrl+C terminal1 when you don't need debug pod anymore)
 
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- \
+  oc adm must-gather --image-stream openshift/network-tools:latest -- \
       network-tools pod-run-netns-command default hello-pod nc -z -v <ip> <port>
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- \
+  oc adm must-gather --image-stream openshift/network-tools:latest -- \
       "network-tools pod-run-netns-command default hello-pod ping 8.8.8.8 -c 5 > /must-gather/ping"
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- \
+  oc adm must-gather --image-stream openshift/network-tools:latest -- \
       "network-tools pod-run-netns-command default hello-pod timeout 30 tcpdump > /must-gather/tcpdump_output"
 
   To run multiple commands, use
-      oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- \
+      oc adm must-gather --image-stream openshift/network-tools:latest -- \
           network-tools pod-run-netns-command --multiple-commands default hello-pod '"<command1>; <command2>"'
       Example:
-          oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- \
+          oc adm must-gather --image-stream openshift/network-tools:latest -- \
               network-tools pod-run-netns-command -mc default hello-pod '"ifconfig; ip a"'
   To prevent parameter expansion, use
-      oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- \
+      oc adm must-gather --image-stream openshift/network-tools:latest -- \
           network-tools pod-run-netns-command --no-substitution default hello-pod "'"'<command to run>'"'"
       Example:
-          oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- \
+          oc adm must-gather --image-stream openshift/network-tools:latest -- \
               network-tools pod-run-netns-command -ns default hello-pod "'"'i=0; ip a; i=$(( $i + 1 )); echo $i'"'"
 
   If the command you are running generates a file instead of output, you can download that file by preserving debug pod
-      [terminal1] oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest --  \
+      [terminal1] oc adm must-gather --image-stream openshift/network-tools:latest --  \
           network-tools pod-run-netns-command -pp default hello-pod timeout 10 tcpdump -w /tmp/tcpdump.pcap
 
       # wait for
@@ -329,7 +327,7 @@ Usage: network-tools network-test
 Examples:
   network-tools network-test
 
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools network-test
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools network-test
 
 ```
 * `network-tools ovn-ipsec-connectivity`
@@ -351,7 +349,7 @@ Usage: network-tools ovn-ipsec-connectivity
 Examples:
   network-tools ovn-ipsec-connectivity
 
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-ipsec-connectivity
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools ovn-ipsec-connectivity
 
 ```
 * `network-tools ovn-nic-firmware`
@@ -366,7 +364,7 @@ Usage: network-tools ovn-nic-firmware
 Examples:
   network-tools ovn-nic-firmware
 
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-nic-firmware
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools ovn-nic-firmware
 
 ```
 * `network-tools ovn-pod-to-pod`
@@ -394,11 +392,11 @@ Examples:
   network-tools ovn-pod-to-pod "" <dst-pod-namespace>/<dst-pod-name>
   network-tools ovn-pod-to-pod <src-pod-namespace>/<src-pod-name>
 
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-pod-to-pod
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-pod-to-pod <src-node-name> <dst-node-name>
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-pod-to-pod <src-pod-namespace>/<src-pod-name> <dst-pod-namespace>/<dst-pod-name>
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-pod-to-pod \"\" <dst-pod-namespace>/<dst-pod-name>
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-pod-to-pod <src-pod-namespace>/<src-pod-name>
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools ovn-pod-to-pod
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools ovn-pod-to-pod <src-node-name> <dst-node-name>
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools ovn-pod-to-pod <src-pod-namespace>/<src-pod-name> <dst-pod-namespace>/<dst-pod-name>
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools ovn-pod-to-pod \"\" <dst-pod-namespace>/<dst-pod-name>
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools ovn-pod-to-pod <src-pod-namespace>/<src-pod-name>
 
 ```
 * `network-tools ovn-pod-to-svc`
@@ -430,11 +428,11 @@ Examples:
   network-tools ovn-pod-to-svc "" <dst-pod-namespace>/<dst-pod-name>
   network-tools ovn-pod-to-svc <src-pod-namespace>/<src-pod-name>
 
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-pod-to-svc
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-pod-to-svc <src-node-name> <dst-node-name>
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-pod-to-svc <src-pod-namespace>/<src-pod-name> <dst-svc-namespace>/<dst-svc-name>
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-pod-to-svc \"\" <dst-svc-namespace>/<dst-svc-name>
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools ovn-pod-to-svc <src-pod-namespace>/<src-pod-name>
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools ovn-pod-to-svc
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools ovn-pod-to-svc <src-node-name> <dst-node-name>
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools ovn-pod-to-svc <src-pod-namespace>/<src-pod-name> <dst-svc-namespace>/<dst-svc-name>
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools ovn-pod-to-svc \"\" <dst-svc-namespace>/<dst-svc-name>
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools ovn-pod-to-svc <src-pod-namespace>/<src-pod-name>
 
 ```
 * `network-tools sdn-cluster-info`
@@ -456,7 +454,7 @@ Usage: network-tools sdn-cluster-info [node_name]
 Examples:
   network-tools sdn-cluster-info
 
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools sdn-cluster-info
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools sdn-cluster-info
 
 ```
 * `network-tools sdn-node-connectivity`
@@ -466,10 +464,10 @@ Examples:
 This script checks the node connectivity on an Openshift SDN cluster from a must-gather pod.
 ATTENTION! Can't be run locally
 
-Usage: oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools sdn-node-connectivity
+Usage: oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools sdn-node-connectivity
 
 Examples:
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools sdn-node-connectivity
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools sdn-node-connectivity
 
 ```
 * `network-tools sdn-pod-to-pod`
@@ -495,11 +493,11 @@ Examples:
   network-tools sdn-pod-to-pod "" <dst-pod-namespace>/<dst-pod-name>
   network-tools sdn-pod-to-pod <src-pod-namespace>/<src-pod-name>
 
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools sdn-pod-to-pod
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools sdn-pod-to-pod <src-node-name> <dst-node-name>
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools sdn-pod-to-pod <src-pod-namespace>/<src-pod-name> <dst-pod-namespace>/<dst-pod-name>
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools sdn-pod-to-pod \"\" <dst-pod-namespace>/<dst-pod-name>
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools sdn-pod-to-pod <src-pod-namespace>/<src-pod-name>
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools sdn-pod-to-pod
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools sdn-pod-to-pod <src-node-name> <dst-node-name>
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools sdn-pod-to-pod <src-pod-namespace>/<src-pod-name> <dst-pod-namespace>/<dst-pod-name>
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools sdn-pod-to-pod \"\" <dst-pod-namespace>/<dst-pod-name>
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools sdn-pod-to-pod <src-pod-namespace>/<src-pod-name>
 
 ```
 * `network-tools sdn-pod-to-svc`
@@ -528,11 +526,11 @@ Examples:
   network-tools sdn-pod-to-svc "" <dst-pod-namespace>/<dst-pod-name>
   network-tools sdn-pod-to-svc <src-pod-namespace>/<src-pod-name>
 
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools sdn-pod-to-svc
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools sdn-pod-to-svc <src-node-name> <dst-node-name>
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools sdn-pod-to-svc <src-pod-namespace>/<src-pod-name> <dst-svc-namespace>/<dst-svc-name>
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools sdn-pod-to-svc \"\" <dst-svc-namespace>/<dst-svc-name>
-  oc adm must-gather --image=quay.io/openshift/origin-network-tools:latest -- network-tools sdn-pod-to-svc <src-pod-namespace>/<src-pod-name>
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools sdn-pod-to-svc
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools sdn-pod-to-svc <src-node-name> <dst-node-name>
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools sdn-pod-to-svc <src-pod-namespace>/<src-pod-name> <dst-svc-namespace>/<dst-svc-name>
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools sdn-pod-to-svc \"\" <dst-svc-namespace>/<dst-svc-name>
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools sdn-pod-to-svc <src-pod-namespace>/<src-pod-name>
 
 ```
 * `network-tools ci-artifacts-get`


### PR DESCRIPTION
Since https://github.com/openshift/cluster-samples-operator/pull/495 we have image stream for network-tools, so we should use it instead of quay image. It exists for 4.13+ clusters
