### PR TITLE
SDN-4189: Add flow counter script for ACLs

### DIFF
--- a/debug-scripts/network-tools
+++ b/debug-scripts/network-tools
@@ -51,6 +51,7 @@ function main() {
     declare -A -x other_commands=(
         ["ovn-metrics-list"]="./scripts/ovn-metrics-list"
         ["ovn-get"]="./scripts/ovn-get"
+        ["ovn-count-flows"]="./scripts/ovn-count-flows"
         ["ovn-db-run-command"]="./scripts/ovn-db-run-command"
         ["pod-run-netns-command"]="./scripts/pod-run-netns-command"
     )

--- a/debug-scripts/scripts/ovn-count-flows
+++ b/debug-scripts/scripts/ovn-count-flows
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -euo pipefail
+source ./utils
+
+description() {
+  echo "Count OVS flows for nbdb tables (only implemented for ACLs now)."
+}
+
+help () {
+  echo "This script collects the number of OVS flows for a given pod, and maps it to the nbdb ACL data.
+The result depends on the given pod, since some ACLs are not translated to OVS flows, e.g. if port group ports don't
+exist on a given node.
+
+Usage: $USAGE [-l limit] [pod_name]
+
+Options:
+  pod_name:
+    use given pod to count OVS flows, should have ovs-ofctl installed.
+
+  limit (optional, default value is 5):
+    the number of flows to print information for (db entries translated to the highest number of OVS flows are printed first)
+
+Examples:
+  $USAGE -l 10 ovnkube-node-2dwl7
+  $USAGE ovnkube-node-2dwl7
+
+  oc adm must-gather $NETWORK_TOOLS_IMAGE -- $USAGE -l 10 ovnkube-node-2dwl7
+"
+}
+
+main() {
+    if [[ "$1" == "-l" ]]; then
+      limit="$2"
+      shift 2
+    else
+      limit=5
+    fi
+    pod="$1"
+    db_pod=$pod
+    if [ $(get_ovn_mode) != "ovn-ic" ]; then
+      # Legacy mode support: pod parameter is not necessary on 4.13 and older releases
+      db_pod=$(get_ovndb_leader_pod n)
+      echo "Leader pod is $db_pod"
+    fi
+    echo "NOTE: Every ACL will likely be printed twice, that is expected and means that the number of OVS flows for a given ACL \
+is a sum of all entries with the same name+ids"
+    NODE_CONTAINER="$(get_ovn_node_container_name)"
+    MASTER_CONTAINER="$(get_ovn_controller_container_name)"
+    ovs_stat=$(oc exec -c $NODE_CONTAINER -n $OVN_NAMESPACE $pod -- bash -c "ovs-ofctl dump-flows br-int | grep cookie | cut -d , -f 1 | sort -n | uniq -c | sort -n -r")
+    oc exec -c $MASTER_CONTAINER -n $OVN_NAMESPACE $db_pod -- bash -c '
+    limit=$0
+    ovs_stat=$1
+    iterations_counter=0
+    echo "$ovs_stat" | while read -r str; do
+      counter=$(echo $str | cut -d " " -f 1)
+      cookie=$(echo $str | cut -d = -f 2 | cut -d x -f 2)
+      nbdb_hint=$(ovn-sbctl --if-exist get logical_flow $cookie external_ids:stage-hint | tr -d \")
+      if [ -n "$nbdb_hint" ]; then
+        acl_ids=$(ovn-nbctl --if-exist get acl $nbdb_hint name external_ids)
+        if [ -n "$acl_ids" ]; then
+          echo Number of OVS flows=$counter for ACL with name and ids = $acl_ids
+          iterations_counter=$((iterations_counter+1))
+          if [ "$iterations_counter" -ge "$limit" ]; then
+            echo "Iterations limit is reached"
+            exit 0
+          fi
+        fi
+      fi
+    done' $limit "$ovs_stat"
+}
+
+case "${1:-}" in
+  description) description ;;
+  -h|--help) help ;;
+  *) main "$@" ;;
+esac

--- a/debug-scripts/utils
+++ b/debug-scripts/utils
@@ -51,6 +51,12 @@ function get_ovn_controller_container_name {
   echo ${OVN_CONTAINER}
 }
 
+function get_ovn_node_container_name {
+  OVN_CONTAINER="ovnkube-controller"
+  [ $(get_ovn_mode) == "ovn-ic" ] || OVN_CONTAINER="ovnkube-node"
+  echo ${OVN_CONTAINER}
+}
+
 get_ovndb_pods () {
   NODE_PODS=$(oc -n ${OVN_NAMESPACE} get pods -l app=ovnkube-node -o=jsonpath='{.items[*].metadata.name}' || { echo "Can't get ovnkube-node pods" 1>&2; exit 1; })
   echo ${NODE_PODS}

--- a/docs/user.md
+++ b/docs/user.md
@@ -133,6 +133,29 @@ To copy a folder from network-tools container use `--source-dir '<container dir>
 # Available `network-tools` commands
 
 The following part of this file is auto-generated based on commands help.
+* `network-tools ovn-count-flows`
+
+```
+This script collects the number of OVS flows for a given pod, and maps it to the nbdb ACL data.
+The result depends on the given pod, since some ACLs are not translated to OVS flows, e.g. if port group ports don't
+exist on a given node.
+
+Usage: network-tools ovn-count-flows [-l limit] [pod_name]
+
+Options:
+  pod_name:
+    use given pod to count OVS flows, should have ovs-ofctl installed.
+
+  limit (optional, default value is 5):
+    the number of flows to print information for (db entries translated to the highest number of OVS flows are printed first)
+
+Examples:
+  network-tools ovn-count-flows -l 10 ovnkube-node-2dwl7
+  network-tools ovn-count-flows ovnkube-node-2dwl7
+
+  oc adm must-gather --image-stream openshift/network-tools:latest -- network-tools ovn-count-flows -l 10 ovnkube-node-2dwl7
+
+```
 * `network-tools ovn-db-run-command`
 
 ```


### PR DESCRIPTION
Required to investigate ACLs (network policy) impact in the OVS flows number.
Expected output:
```
$ network-tools ovn-count-flows -l 10 ovnkube-node-6pnpv
Leader pod is ovnkube-master-t679l
NOTE: Every ACL will likely be printed twice, that is expected and means that the number of OVS flows for a given ACL is a sum of all entries with the same name+ids
Number of OVS flows=12 for ACL with name and ids = clusterPortGroup_DefaultDenyMulticastEgress {default-deny-policy-type=Egress}
Number of OVS flows=12 for ACL with name and ids = clusterRtrPortGroup_DefaultAllowMulticastEgress {default-deny-policy-type=Egress}
Number of OVS flows=12 for ACL with name and ids = clusterRtrPortGroup_DefaultAllowMulticastIngress {default-deny-policy-type=Ingress}
Number of OVS flows=12 for ACL with name and ids = clusterRtrPortGroup_DefaultAllowMulticastEgress {default-deny-policy-type=Egress}
Number of OVS flows=12 for ACL with name and ids = clusterPortGroup_DefaultDenyMulticastIngress {default-deny-policy-type=Ingress}
Number of OVS flows=12 for ACL with name and ids = clusterPortGroup_DefaultDenyMulticastEgress {default-deny-policy-type=Egress}
Number of OVS flows=12 for ACL with name and ids = clusterPortGroup_DefaultDenyMulticastIngress {default-deny-policy-type=Ingress}
Number of OVS flows=12 for ACL with name and ids = clusterRtrPortGroup_DefaultAllowMulticastIngress {default-deny-policy-type=Ingress}
Number of OVS flows=1 for ACL with name and ids = [] {}
Number of OVS flows=1 for ACL with name and ids = [] {}
Iterations limit is reached
```