### PR TITLE
SDN-4189: Update OVS flows counter to work for cookies with leading 0.

### DIFF
--- a/debug-scripts/scripts/ovn-count-flows
+++ b/debug-scripts/scripts/ovn-count-flows
@@ -55,6 +55,9 @@ is a sum of all entries with the same name+ids"
     echo "$ovs_stat" | while read -r str; do
       counter=$(echo $str | cut -d " " -f 1)
       cookie=$(echo $str | cut -d = -f 2 | cut -d x -f 2)
+      while [[ ${#cookie} < 8 ]]; do
+        cookie=0$cookie
+      done
       nbdb_hint=$(ovn-sbctl --no-leader-only --if-exist get logical_flow $cookie external_ids:stage-hint | tr -d \")
       if [ -n "$nbdb_hint" ]; then
         acl_ids=$(ovn-nbctl --no-leader-only --if-exist get acl $nbdb_hint name external_ids)


### PR DESCRIPTION
When logical flows are translated to OVS flows, first 8 chars of logical_flow UUID are used as a cookie, but leading zeros are dropped. To create a valid sbdb request, restore missing zeros knowing we expect is to be 8 chars.