### PR TITLE
NO-JIRA:Fix bug list formatting in verbose mode and remove metal lb component

### DIFF
--- a/jira-scripts/network_bugs_overview
+++ b/jira-scripts/network_bugs_overview
@@ -101,7 +101,6 @@ GENERIC_COMPONENT = "networking"
 SDN_COMPONENT = "networking / openshift-sdn"
 OVN_COMPONENT = "networking / ovn-kubernetes"
 INGRESS_FW_COMPONENT = "networking / ingress-node-firewall"
-METAL_LB_COMPONENT = "networking / metal LB"
 CNO_COMPONENT = "networking / cluster-network-operator"
 CNCC_COMPONENT = "networking / cloud-network-config-controller"
 NETWORK_TOOLS_COMPONENT = "networking / network-tools"
@@ -112,7 +111,6 @@ TEAM_COMPONENTS = (
     OVN_COMPONENT,
     CNCC_COMPONENT,
     INGRESS_FW_COMPONENT,
-    METAL_LB_COMPONENT,
     CNO_COMPONENT,
     NETWORK_TOOLS_COMPONENT,
 )

--- a/jira-scripts/network_bugs_overview
+++ b/jira-scripts/network_bugs_overview
@@ -904,7 +904,8 @@ def print_results(developers, stale_bugs, print_stale_bugs=False, quick=False):
                     ASSIGN_WINDOW_DAYS, v["recently_assigned"]
                 )
             )
-        print("  Bug URLs:    {}".format(v["bugs_urls"]))
+        bugs_urls = ("\n\t\t- " + ("\n\t\t- ".join(v["bugs_urls"])))
+        print("  Bug URLs:    {}".format(bugs_urls))
         print("")
 
     print(colors.HEADER + "\nBug status explained:" + colors.END)


### PR DESCRIPTION
Example output:
```
$ ./network_bugs_overview -vq
- Found 118 bugs in 8.8s with the query: project=OCPBUGS and component in ("networking", "networking / openshift-sdn", "networking / ovn-kubernetes", "networking / cloud-network-config-controller", "networking / ingress-node-firewall", "networking / cluster-network-operator", "networking / network-tools") and status in ("NEW", "ASSIGNED", "POST", "ON_DEV")
- Found 13 bugs in 1.7s with the query: project = SDN AND "Epic Link" = SDN-4175 AND Summary ~ "upstream-*" AND filter in (Unresolved) AND assignee != "bbennett@redhat.com" AND assignee is not EMPTY

Rank of developers least overloaded (today) [2024-02-07]:
========================================================
#1 Developer: bpickard@redhat.com
  Rank Points: 210
  Bugs:        3
  OVN-K        2
  OSDN:        1
  Other:       0
  NEW:         3
  ASSIGNED:    0
  POST:        0
  Bug URLs:    
		- https://issues.redhat.com/browse/OCPBUGS-29118
		- https://issues.redhat.com/browse/OCPBUGS-29073
		- https://issues.redhat.com/browse/OCPBUGS-26199

#2 Developer: jcaamano@redhat.com
  Rank Points: 220
  Bugs:        4
  OVN-K        4
  OSDN:        0
  Other:       0
  NEW:         2
  ASSIGNED:    2
  POST:        0
  Bug URLs:    
		- https://issues.redhat.com/browse/OCPBUGS-28612
		- https://issues.redhat.com/browse/OCPBUGS-27853
		- https://issues.redhat.com/browse/OCPBUGS-27513
		- https://issues.redhat.com/browse/OCPBUGS-27316
[...]
```