### PR TITLE
OCPBUGS-31699: replace wireshark with wireshark-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN INSTALL_PKGS="\
     nginx \
     numactl \
     traceroute \
-    wireshark \
+    wireshark-cli \
     conntrack-tools \
     perf \
     iproute \

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -56,7 +56,7 @@ RUN INSTALL_PKGS="\
     nginx \
     numactl \
     traceroute \
-    wireshark \
+    wireshark-cli \
     conntrack-tools \
     perf \
     iproute \

--- a/docs/user.md
+++ b/docs/user.md
@@ -63,7 +63,7 @@ To run script that are not included in the `network-tools -h` call them directly
 * nginx
 * numactl
 * traceroute
-* wireshark
+* wireshark-cli
 * conntrack-tools
 * perf
 * iproute


### PR DESCRIPTION
wireshark was added here https://github.com/openshift/network-tools/pull/20 and only needs `tshark` to work.