### PR TITLE
SDN-4168: Add required packages for IPsec tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN INSTALL_PKGS="\
     bcc \
     bcc-tools \
     python3-bcc \
+    libreswan \
+    butane \
+    openssl \
     " && \
     yum -y install --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
     yum clean all && rm -rf /var/cache/*

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -63,6 +63,9 @@ RUN INSTALL_PKGS="\
     bcc \
     bcc-tools \
     python3-bcc \
+    libreswan \
+    butane \
+    openssl \
     " && \
     yum -y install --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
     yum clean all && rm -rf /var/cache/*


### PR DESCRIPTION
This adds required packages into network-tools image and it would help build and import certificates onto worker nodes for IPsec north south e2e test. For more information, see the comment [here](https://github.com/openshift/origin/pull/28658/commits/8a66229b23a687544e3a332320eee2d3323eff39#diff-171496901153a36ea9127c00c510f03758d598927be689320eaeb044f464e932R731-R735).