### PR TITLE
Add bpftrace to networking tools image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN INSTALL_PKGS="\
     bcc \
     bcc-tools \
     python3-bcc \
+    bpftrace \
     " && \
     yum -y install --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
     yum clean all && rm -rf /var/cache/*

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -63,6 +63,7 @@ RUN INSTALL_PKGS="\
     bcc \
     bcc-tools \
     python3-bcc \
+    bpftrace \
     " && \
     yum -y install --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
     yum clean all && rm -rf /var/cache/*


### PR DESCRIPTION
There is a need from customers and partners to debug eBPF probes on openshift clusters.
we added bcc tools and bpftrace and the related packages: there seems to be more familiarity with bpftrace rather than bcc tools.
