### PR TITLE
SDN-4114: add packages for iptables-alerter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,16 +16,16 @@ RUN rm -rf /opt/bin/local-scripts && ln -s /opt/bin/network-tools /usr/bin/netwo
 
 # Make sure to maintain alphabetical ordering when adding new packages.
 RUN INSTALL_PKGS="\
-    nginx \
-    numactl \
-    traceroute \
-    wireshark-cli \
-    conntrack-tools \
-    perf \
-    iproute \
     bcc \
     bcc-tools \
+    conntrack-tools \
+    iproute \
+    nginx \
+    numactl \
+    perf \
     python3-bcc \
+    traceroute \
+    wireshark-cli \
     " && \
     yum -y install --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
     yum clean all && rm -rf /var/cache/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,9 @@ RUN INSTALL_PKGS="\
     bcc \
     bcc-tools \
     conntrack-tools \
+    cri-tools \
     iproute \
+    iptables \
     nginx \
     numactl \
     perf \

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -22,6 +22,7 @@ RUN INSTALL_PKGS="\
     bind-utils \
     blktrace \
     crash \
+    cri-tools \
     e2fsprogs \
     ethtool \
     file \
@@ -31,6 +32,7 @@ RUN INSTALL_PKGS="\
     hwloc \
     iotop \
     iproute \
+    iptables-nft \
     iputils \
     jq \
     less \


### PR DESCRIPTION
Adds `crictl` and `iptables`, to support the iptables-alerter (https://github.com/openshift/cluster-network-operator/pull/2329)