### PR TITLE
NO-JIRA: Px score for bugs

### DIFF
--- a/jira-scripts/network_bugs_overview
+++ b/jira-scripts/network_bugs_overview
@@ -1071,7 +1071,7 @@ def print_unassigned_bugs():
         bug_url = get_jira_issue_url(bug)
         bug_summary = bug.get_field("summary")
         bug_issuetype = bug.get_field("issuetype")
-        if str(bug_issuetype) == "Bug":
+        if str(bug_issuetype) == "Bug" and str(bug) in "OCPBUGS":
             bug_px_score = bug.get_field("customfield_12322244")
             if bug_px_score is not None:
                 bug_px_score=int(bug_px_score)

--- a/jira-scripts/network_bugs_overview
+++ b/jira-scripts/network_bugs_overview
@@ -1070,7 +1070,14 @@ def print_unassigned_bugs():
     for bug in unassigned_bugs:
         bug_url = get_jira_issue_url(bug)
         bug_summary = bug.get_field("summary")
-        print(f"- [{bug}]({bug_url}) - {bug_summary}")
+        bug_issuetype = bug.get_field("issuetype")
+        if str(bug_issuetype) == "Bug":
+            bug_px_score = bug.get_field("customfield_12322244")
+            if bug_px_score is not None:
+                bug_px_score=int(bug_px_score)
+            print(f"- [{bug}]({bug_url}) - [{bug_px_score}] {bug_summary}")
+        else:
+            print(f"- [{bug}]({bug_url}) - {bug_summary}")
 
 
 def parse_input_args():

--- a/jira-scripts/network_bugs_overview
+++ b/jira-scripts/network_bugs_overview
@@ -1071,10 +1071,12 @@ def print_unassigned_bugs():
         bug_url = get_jira_issue_url(bug)
         bug_summary = bug.get_field("summary")
         bug_issuetype = bug.get_field("issuetype")
-        if str(bug_issuetype) == "Bug" and str(bug) in "OCPBUGS":
+        if str(bug_issuetype) == "Bug" and "OCPBUGS" in str(bug):
             bug_px_score = bug.get_field("customfield_12322244")
             if bug_px_score is not None:
                 bug_px_score=int(bug_px_score)
+            else:
+                bug_px_score= "no px score"
             print(f"- [{bug}]({bug_url}) - [{bug_px_score}] {bug_summary}")
         else:
             print(f"- [{bug}]({bug_url}) - {bug_summary}")


### PR DESCRIPTION
This PR adds the "PX Impact Score" to the output for --new-bugs to the ./network_bugs_overview script. PX Impact Score is from the "Product Experience" tab in OCPBUGS and is a numeric "severity" that is calculated by an algorithm described here: [PX Prioritization Algorithm Details](https://spaces.redhat.com/pages/viewpage.action?spaceKey=PPE&title=PX+Prioritization+Algorithm+Details)

Basically, every bugs starts out with a score of 6000. There are 4 factors that can increase the score up to 12000:

- The total quantity of linked cases
- The quantity of linked cases with a specific severity
- The "complexity" and quantity of the linked cases
- PX properties like "Impact range" and "technical impact" set manually by me (or anyone)

I'd like to get Px Impact Score into the output for new bugs as an acid test for prioritization.  Higher score means more customer impact.  

