### PR TITLE
OCPBUGS-45318: change containerRuntime from runc to crun

### DIFF
--- a/debug-scripts/test-networking/common
+++ b/debug-scripts/test-networking/common
@@ -111,7 +111,7 @@ run_command_inside_pod_network_namespace() {
 
     node_name="$(get_pod_node "$namespace" "$pod")"
     ans="$(oc debug node/"$node_name" -- chroot /host bash -c \
-        "nsenter -n -t \$(runc state \$(crictl ps --pod \$(crictl pods --namespace $namespace --name $pod -q) -q) | jq .pid) $command")"
+        "nsenter -n -t \$(crun state \$(crictl ps --pod \$(crictl pods --namespace $namespace --name $pod -q) -q) | jq .pid) $command")"
     echo "
 INFO: command output
 

--- a/debug-scripts/utils
+++ b/debug-scripts/utils
@@ -61,7 +61,7 @@ get_netns_pid() {
 
   node_name="$(get_pod_node "$namespace" "$pod")"
   ns_pid=$(oc debug node/"$node_name" -- chroot /host bash -c \
-                 "runc state \$(crictl ps --pod \$(crictl pods --namespace $namespace --name $pod -q) -q) | jq .pid" || \
+                 "crun state \$(crictl ps --pod \$(crictl pods --namespace $namespace --name $pod -q) -q) | jq .pid" || \
                   { echo "ERROR: Can't get netns pid" 1>&2; exit 1; })
   echo "$ns_pid"
 }


### PR DESCRIPTION
The containerRuntime changed from runc to crun from 4.18, so we need to update network-tools utils.
/cc @npinaeva 
PTAL, thanks so much ^ ^