### PR TITLE
[ART-11792]  add missing go vendors

### DIFF
--- a/vendor/github.com/openshift/build-machinery-go/go.mod
+++ b/vendor/github.com/openshift/build-machinery-go/go.mod
@@ -1,3 +1,0 @@
-module github.com/openshift/build-machinery-go
-
-go 1.13

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,5 @@
 # github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab
-## explicit
+## explicit; go 1.13
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make
 github.com/openshift/build-machinery-go/make/lib


### PR DESCRIPTION
Image build for network-tools on 4.16 was failing on Konflux due to missing go mod dependencies.

```
2025-03-25 21:08:20,106 ERROR vendor/modules.txt changed after vendoring:
diff --git a/vendor/modules.txt b/vendor/modules.txt
index 11b55ac..ca0e58f 100644
--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,5 @@
 # github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab
-## explicit
+## explicit; go 1.13
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make
 github.com/openshift/build-machinery-go/make/lib
2025-03-25 21:08:20,130 ERROR PackageRejected: The content of the vendor directory is not consistent with go.mod.
```
