### PR TITLE
NO-JIRA: Image slimming

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN INSTALL_PKGS="\
     iproute \
     nginx \
     numactl \
-    perf \
     traceroute \
     wireshark-cli \
     " && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,14 +16,11 @@ RUN rm -rf /opt/bin/local-scripts && ln -s /opt/bin/network-tools /usr/bin/netwo
 
 # Make sure to maintain alphabetical ordering when adding new packages.
 RUN INSTALL_PKGS="\
-    bcc \
-    bcc-tools \
     conntrack-tools \
     iproute \
     nginx \
     numactl \
     perf \
-    python3-bcc \
     traceroute \
     wireshark-cli \
     " && \


### PR DESCRIPTION
Removing bcc, bcc-tools, and perf eliminates ~650 MiB of content from the image including two (three?) compiler toolchains. Additionally, given the size of dependencies here the network-tools image frequently times out during builds which is a problem unto itself, but if these tools are used in extremely rare situations we should forego them.

```
sh-5.1# dnf remove bcc perf
============================================================================================================================================================================================
 Package                                          Architecture             Version                                   Repository                                                        Size
============================================================================================================================================================================================
Removing:
 bcc                                              x86_64                   0.28.0-8.el9_4                            @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                   2.3 M
 perf                                             x86_64                   5.14.0-427.102.1.el9_4                    @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                   9.9 M
Removing dependent packages:
 bcc-tools                                        x86_64                   0.28.0-8.el9_4                            @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                   1.9 M
 python3-bcc                                      noarch                   0.28.0-8.el9_4                            @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                   391 k
Removing unused dependencies:
 bison                                            x86_64                   3.7.4-5.el9                               @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                   3.1 M
 bzip2                                            x86_64                   1.0.8-8.el9_4.1                           @rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_4                       93 k
 clang-libs                                       x86_64                   17.0.6-5.el9                              @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                   113 M
 clang-resource-filesystem                        noarch                   17.0.6-5.el9                              @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                   476  
 compiler-rt                                      x86_64                   17.0.6-1.el9                              @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                    28 M
 cpp                                              x86_64                   11.4.1-4.el9_4                            @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                    29 M
 elfutils-libelf-devel                            x86_64                   0.190-2.el9                               @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                    34 k
 flex                                             x86_64                   2.6.4-9.el9                               @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                   902 k
 gcc                                              x86_64                   11.4.1-4.el9_4                            @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                    85 M
 gcc-toolset-13-gcc                               x86_64                   13.3.1-2.2.el9_4                          @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                   110 M
 gcc-toolset-13-gcc-c++                           x86_64                   13.3.1-2.2.el9_4                          @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                    35 M
 gcc-toolset-13-libstdc++-devel                   x86_64                   13.3.1-2.2.el9_4                          @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                    21 M
 glibc-devel                                      x86_64                   2.34-100.el9_4.12                         @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                    37 k
 glibc-headers                                    x86_64                   2.34-100.el9_4.12                         @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                   2.1 M
 kernel-devel                                     x86_64                   5.14.0-427.102.1.el9_4                    @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                    67 M
 kernel-headers                                   x86_64                   5.14.0-427.102.1.el9_4                    @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                   5.9 M
 libatomic                                        x86_64                   11.4.1-4.el9_4                            @rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_4                       29 k
 libbabeltrace                                    x86_64                   1.5.8-10.el9                              @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                   517 k
 libmpc                                           x86_64                   1.2.1-4.el9                               @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                   135 k
 libomp                                           x86_64                   17.0.6-1.el9                              @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                   2.2 M
 libomp-devel                                     x86_64                   17.0.6-1.el9                              @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                    20 M
 libtraceevent                                    x86_64                   1.5.3-3.el9                               @rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_4                      1.2 M
 libxcrypt-devel                                  x86_64                   4.4.18-3.el9                              @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                    30 k
 libzstd-devel                                    x86_64                   1.5.1-2.el9                               @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                   174 k
 llvm-libs                                        x86_64                   17.0.6-5.el9                              @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                   102 M
 m4                                               x86_64                   1.4.19-1.el9                              @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                   582 k
 make                                             x86_64                   1:4.3-8.el9                               @rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_4                      1.6 M
 openssl-devel                                    x86_64                   1:3.0.7-29.el9_4.1                        @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                   4.7 M
 python3-netaddr                                  noarch                   0.8.0-5.el9                               @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                   9.4 M
 slang                                            x86_64                   2.3.2-11.el9                              @rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_4                      1.3 M
 zlib-devel                                       x86_64                   1.2.11-40.el9                             @rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_4                   138 k

Transaction Summary
============================================================================================================================================================================================
Remove  35 Packages

Freed space: 658 M
Is this ok [y/N]: n
```