### PR TITLE
NO-JIRA: add tooling to reduce bug backlog toil for viewing bz comment updates

### DIFF
--- a/jira-scripts/network_bugs_overview
+++ b/jira-scripts/network_bugs_overview
@@ -1170,6 +1170,12 @@ def parse_input_args():
     )
     parser.add_argument("--print-bug", "-p", type=str, help='Given a bug id (e.g. OCPBUGS-123), it will print all the bug internal details as seen from the jira client. Useful for debugging this script.')
 
+    parser.add_argument(
+        "--recent-bot-bug-comments",
+        help="List bug issues assigned to 'sdn-team-bot' with comments for the last 4 days",
+        action="store_true",
+    )
+
     args = parser.parse_args()
 
     # By default jira bugs are queried and parsed. Jira escalations are not.
@@ -1201,17 +1207,67 @@ def parse_input_args():
         "quick": bool(args.quick),
         "new_bugs": new_bugs,
         "process_github_issues": process_github_issues,
-        "print_bug": args.print_bug
+        "print_bug": args.print_bug,
+        "recent_bot_bug_comments": bool(args.recent_bot_bug_comments)
     }
 
     return params
 
+
+def list_recent_bug_comments():
+    """List bug issues assigned to 'sdn-team-bot' with comments for the last 4 days.."""
+    from datetime import datetime, timedelta
+    jira_client = init_jira()
+    # Query for bug issues assigned to sdn-team-bot
+    query = f'assignee = "{SDN_TEAM_BOT_ASSIGNEE}@redhat.com" AND type = Bug AND resolution = Unresolved'
+    bugs = run_jira_query(jira_client, query)
+    if not bugs:
+        print("No bug issues found assigned to 'sdn-team-bot'")
+        return
+    print(f"Checking {len(bugs)} bug issues assigned to 'sdn-team-bot' for recent comments...")
+    print("=" * 70)
+    forty_eight_hours_ago = datetime.now() - timedelta(hours=96)
+    found_recent = False
+    for bug in bugs:
+        try:
+            comments = jira_client.comments(bug)
+            # Check if there are comments in the last 48 hours
+            recent_comments = []
+            for comment in comments:
+                comment_time = parse(comment.created).replace(tzinfo=None)
+                if comment_time > forty_eight_hours_ago:
+                    recent_comments.append(comment)
+            if recent_comments:
+                found_recent = True
+                bug_url = get_jira_issue_url(bug.key)
+                priority = bug.fields.priority.name if bug.fields.priority else "None"
+                # Try to get severity from common custom fields
+                severity = getattr(bug.fields, 'customfield_12316142', None)
+                if severity and hasattr(severity, 'value'):
+                    severity = severity.value
+                elif severity:
+                    severity = str(severity)
+                else:
+                    severity = "Unknown"
+                print(f"\n🐛 {bug.fields.summary}")
+                print(f"   Link: {bug_url}")
+                print(f"   Priority: {priority} | Severity: {severity}")
+                print(f"   Recent comments found: {len(recent_comments)} for the last 4 days")
+        except Exception as e:
+            print(f"Error processing bug {bug.key}: {e}")
+            continue
+    if not found_recent:
+        print("No bug issues with comments for the last 4 days found.")
 
 def main():
     params = parse_input_args()
 
     if params.get("print_bug"):
         print_bug(params["print_bug"])
+        return
+
+    if params.get("recent_bot_bug_comments"):
+        list_recent_bug_comments()
         return
 
     if params.get("process_github_issues"):


### PR DESCRIPTION
.. for the last 5 days..

The problem I am trying to solve is that there is
not enough resources to manage the bugs on the bot, so we need some tooling to help.
This helps give our networking consumers confidence we are listening and importantly reacting to their updates.

New tool idea in future might also print bugs with severity or priorty change.

Tool will print out bugs that have new comments within the last 4 days with a URL you can click on.


# Sample output

- Found 109 bugs in 20.8s with the query: assignee = "sdn-team-bot@redhat.com" AND type = Bug AND resolution = Unresolved
Checking 109 bug issues assigned to 'sdn-team-bot' for recent comments...
======================================================================

🐛 When mutlicast traffic reaches br-ex OVS bridge is flooding the network causing bandwidth degradation to all attached hosts on it.
   Link: https://issues.redhat.com/browse/OCPBUGS-57009
   Priority: Normal | Severity: Important
   Recent comments found: 1 for the last 4 days

🐛 [UDN L3]nodePort with ETP=cluster service is not working for UDN on LGW mode
   Link: https://issues.redhat.com/browse/OCPBUGS-55366
   Priority: Normal | Severity: Important
   Recent comments found: 2 for the last 4 days

🐛 MetalLB service for a primary udn pod is unreachable from a different UDN/Non-UDN namespace when egressIP and the advertise node is same
   Link: https://issues.redhat.com/browse/OCPBUGS-55152
   Priority: Normal | Severity: Unknown
   Recent comments found: 1 for the last 4 days

🐛 LoadBalancer (MetalLB) service for a Primary UDN Pod with ETP = Local/Cluster is inaccessible from a pod running on the same node as  the LB service advertised node where the source pod exist in different UDN/Node-UDN namespaces
   Link: https://issues.redhat.com/browse/OCPBUGS-54920
   Priority: Major | Severity: Unknown
   Recent comments found: 1 for the last 4 days

🐛 Pod does not get the UDN network in HCP kubevirt
   Link: https://issues.redhat.com/browse/OCPBUGS-54647
   Priority: Normal | Severity: Moderate
   Recent comments found: 1 for the last 4 days
