### PR TITLE
OCPBUGS-53196: Update references of `master` to `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can use almost all the same scripts on the cluster via network-tools image, 
 WARNING! `must-gather` doesn't allow interactive input, don't use interactive options with must-gather.
 WARNING! For clusters older than 4.13, use `--image quay.io/openshift/origin-network-tools:latest` instead of `--image-streams`
 
-For more examples and options check [user docs](https://github.com/openshift/network-tools/blob/master/docs/user.md)
+For more examples and options check [user docs](https://github.com/openshift/network-tools/blob/main/docs/user.md)
 
 ## Debugging Scripts
 Debugging scripts are kept in `debug-scripts`.  The content of that folder is placed in `/opt/bin` in the image.
@@ -40,8 +40,8 @@ are not copied to the image. But these scripts are available for local use (`net
 
 ## Documentation
 
-* Please see [contributor docs](https://github.com/openshift/network-tools/blob/master/docs/contributor.md) for more information regarding the scope of this repository and how to contribute.
-* Users can go to [user docs](https://github.com/openshift/network-tools/blob/master/docs/user.md) for information on how to leverage the tools and scripts shipped by this image.
+* Please see [contributor docs](https://github.com/openshift/network-tools/blob/main/docs/contributor.md) for more information regarding the scope of this repository and how to contribute.
+* Users can go to [user docs](https://github.com/openshift/network-tools/blob/main/docs/user.md) for information on how to leverage the tools and scripts shipped by this image.
 
 ## Contacts
 


### PR DESCRIPTION
As the `master` branch will be renamed to `main`, this PR updates all the existing references of `master` to `main`.

/hold