### PR TITLE
NO-JIRA: Updates to handle changes after migrating to Atlasian cloud

### DIFF
--- a/jira-scripts/network_bugs_overview
+++ b/jira-scripts/network_bugs_overview
@@ -46,6 +46,7 @@ ACCOUNT_ID_TO_USERNAME = {
     "712020:b3d7a67e-6fe1-4aea-8a2f-733c0ccf302d": SDN_TEAM_BOT_ASSIGNEE,  # sdn-team bot
     "70121:4fef5383-e773-49b8-bc72-258f4db6ed69":  DEFAULT_JIRA_ASSIGNEE,  # Ben Bennett
 }
+USERNAME_TO_ACCOUNT_ID = {v: k for k, v in ACCOUNT_ID_TO_USERNAME.items()}
 
 # WARNING 2025: the jira ID for new hires seems to be always prefixed with "rh-ee-" now
 RH_DEVELOPERS = (
@@ -155,6 +156,20 @@ TEAM_COMPONENTS = (
 )
 ASSIGN_WINDOW_DAYS = 21  # 3 weeks in a sprint
 
+def text_to_adf(text):
+    """Convert plain text to Atlassian Document Format required by Jira API v3."""
+    return {
+        "type": "doc",
+        "version": 1,
+        "content": [
+            {
+                "type": "paragraph",
+                "content": [{"type": "text", "text": text}],
+            }
+        ],
+    }
+
+
 def render_rh_developers(name):
     if name.startswith("rhn-support-"):
         return name[len("rhn-support-") :]
@@ -169,7 +184,7 @@ def extract_number_from_jira_id(jira_id):
 
 
 def get_jira_issue_url(jira_issue):
-    return f"https://issues.redhat.com/browse/{jira_issue}"
+    return f"https://redhat.atlassian.net/browse/{jira_issue}"
 
 
 def init_developers_dict():
@@ -250,17 +265,10 @@ def get_query_for_unresolved_jira_stories_tracking_github_issues():
 
 
 def get_jira_assignee_from_github_user(github_user):
-    # When we read or create a story, our jira server is not really consistent in the
-    # assignee format it accepts:
-    # - if a user has an alias, the assignee should be the user name (not the email address)
-    # - if a user has no alias, the assignee should be the email address
+    # Jira API v3 requires accountId for assignee fields.
     jira_user = GITHUB_TO_JIRA_USERS.get(github_user) or DEFAULT_JIRA_ASSIGNEE
-    _, jira_mail = get_username_and_usermail_from_assignee(jira_user)
-    jira_alias, _ = get_alias_and_email_alias_from_username(jira_user)
-    jira_assignee = jira_mail
-    if jira_alias:
-        jira_assignee = jira_user
-    return jira_assignee, jira_user
+    account_id = USERNAME_TO_ACCOUNT_ID.get(jira_user)
+    return account_id, jira_user
 
 
 def open_or_close_jira_story(jira_client, jira_id, action_open=True, comment=""):
@@ -282,7 +290,7 @@ def open_or_close_jira_story(jira_client, jira_id, action_open=True, comment="")
         # Let's add the comment separately.
         if action_open:
             try:
-                jira_client.add_comment(jira_id, comment)
+                jira_client.add_comment(jira_id, text_to_adf(comment))
             except Exception as ex:
                 print(f"--> Failed to add comment to {jira_url}: {comment}. Error: {ex}")
 
@@ -329,7 +337,7 @@ def align_jira_assignee_with_github(jira_client, github_id, github_dict, jira_id
 
     expected_jira_assignee, jira_user = get_jira_assignee_from_github_user(github_assignee)
 
-    if jira_assignee in (expected_jira_assignee, jira_user):
+    if jira_assignee == jira_user:
         return
 
     print(
@@ -398,15 +406,15 @@ def align_jira_with_open_github_issues(github_issues):
             new_jira_description = (
                 f"Tracking ovn-kubernetes upstream issue: {github_issue_url}"
             )
-            new_jira_assignee, _ = get_jira_assignee_from_github_user(github_issue_assignee)
+            new_jira_assignee, new_jira_user = get_jira_assignee_from_github_user(github_issue_assignee)
             # Create a new Jira story
             try:
                 new_jira = jira_client.create_issue(
                     project={"key": "CORENET"},
                     summary=new_jira_summary[:255],  # jira summary must be < 255 characters
-                    description=new_jira_description,
+                    description=text_to_adf(new_jira_description),
                     issuetype={"name": "Story"},
-                    assignee={"name": new_jira_assignee},
+                    assignee={"accountId": new_jira_assignee},
                     customfield_12311140=JIRA_EPIC_FOR_GITHUB_ISSUES,
                 )
             except Exception as ex:
@@ -421,7 +429,7 @@ def align_jira_with_open_github_issues(github_issues):
                 matching_jira_details[new_jira.key] = {
                     "is_open": True,
                     "url": get_jira_issue_url(new_jira.key),
-                    "assignee": new_jira_assignee}
+                    "assignee": new_jira_user}
 
     # Print a list of created jira stories
     if created_jira_stories:
@@ -573,7 +581,7 @@ def init_queries(clients, jira_bugs=True, jira_escalations=False):
 
 
 def init_jira():
-    return JIRA("https://issues.redhat.com", token_auth=secrets["token"], kerberos=True)
+    return JIRA(options={"server": "https://redhat.atlassian.net", "rest_api_version": "3"}, basic_auth=(secrets["email"], secrets["token"]))
 
 
 def init_clients(jira_=True):
@@ -688,7 +696,7 @@ def run_jira_query(jira_api, query, expand_changelog=False):
     max_attempts = 100
     for i in range(max_attempts):
         try:
-            res = jira_api.search_issues(query, expand=expand_value, maxResults=False)
+            res = jira_api.search_issues(query, expand=expand_value, maxResults=False, use_post=True)
         except Exception as ex:
             # print("[attempt {}] Error running JIRA query {}, error: {}".format(
             #     i, query, ex))
@@ -742,7 +750,7 @@ def was_jira_bug_recently_assigned(bug):
     # Evaluate whether the bug
     # Example of the changelog field for a jira bug:
     # {'id': '41700442',
-    #  'author': {'self': 'https://issues.redhat.com/rest/api/2/user?username=rravaiol%40redhat.com',
+    #  'author': {'self': 'https://redhat.atlassian.net/rest/api/3/user?username=rravaiol%40redhat.com',
     #   'name': 'rravaiol@redhat.com',
     #   'key': 'JIRAUSER165708',
     #   'emailAddress': 'rravaiol@redhat.com',

--- a/jira-scripts/network_bugs_overview
+++ b/jira-scripts/network_bugs_overview
@@ -587,6 +587,7 @@ def init_jira():
     try:
         url = jira_client._get_url('myself')
         r = jira_client._session.get(url)
+        r.raise_for_status()
     except Exception as ex:
         sys.exit(f"Jira API token authentication failed. Generate a new token at "
                  f"https://id.atlassian.com/manage-profile/security/api-tokens\n"

--- a/jira-scripts/network_bugs_overview
+++ b/jira-scripts/network_bugs_overview
@@ -1119,11 +1119,13 @@ def print_unassigned_bugs():
         bug_summary = bug.get_field("summary")
         bug_issuetype = bug.get_field("issuetype")
         if str(bug_issuetype) == "Bug" and "OCPBUGS" in str(bug):
-            bug_px_score = bug.get_field("customfield_12322244")
-            if bug_px_score is not None:
-                bug_px_score=int(bug_px_score)
-            else:
-                bug_px_score= "no px score"
+            bug_px_score = getattr(bug.fields, "customfield_11003", None)
+            try:
+                bug_px_score = int(bug_px_score) if bug_px_score is not None else None
+            except (ValueError, TypeError):
+                bug_px_score = None
+            if bug_px_score is None:
+                bug_px_score = "no px score"
             print(f"- [{bug}]({bug_url}) - [{bug_px_score}] {bug_summary}")
         else:
             print(f"- [{bug}]({bug_url}) - {bug_summary}")

--- a/jira-scripts/network_bugs_overview
+++ b/jira-scripts/network_bugs_overview
@@ -26,6 +26,27 @@ DEFAULT_JIRA_ASSIGNEE = "bbennett"
 EXTERNAL_JIRA_ASSIGNEE = "external" # placeholder for all assignees not in the team list
 SDN_TEAM_BOT_ASSIGNEE = "sdn-team-bot"
 
+# Jira Cloud uses accountId instead of username. This mapping translates
+# accountId -> RH_DEVELOPERS username so we can still key developers by email.
+ACCOUNT_ID_TO_USERNAME = {
+    "70121:0fad7649-85f6-49ed-a247-7d7641862d42": "rhn-support-arghosh",   # Arnab Ghosh
+    "712020:892d7637-f1cd-4db8-987f-1f0d225cc88c": "rh-ee-arsen",          # Arkadeep Sen
+    "712020:61bf71fd-6ba7-45de-98b4-3b34bb510754": "rh-ee-mapower",        # Marty Power
+    "712020:5b2f5683-e0c3-4e7d-8a6a-6b844a91af04": "jcaamano",             # Jaime Caamano
+    "712020:b94122c9-36dc-4439-a554-3b2f0a115212": "jluhrsen",             # Jamo Luhrsen
+    "712020:9b800968-bef3-40de-98dd-c2e19c216c28": "rh-ee-ljouin",         # Lionel Jouin
+    "712020:8b6d2da9-7640-4f54-bdd0-30d80e452597": "rh-ee-mdallagl",       # Matteo Dallaglio
+    "70121:1c35a408-cf23-4145-9827-b1cc93cbd64f": "rhn-support-misalunk",  # Miheer Salunke
+    "626ba32ce2f47a00682fbfc0":                    "mkennell",              # Martin Kennelly
+    "712020:7d812864-56db-4370-ac8b-78d97167ff6a": "pdiak",                # Patryk Diak
+    "712020:dbfcf885-e73f-4f5b-ab55-4d78a352993e": "pepalani",             # Periyasamy Palanisamy
+    "5c6e1f975b4c2675327432d4":                    "pliurh",               # Peng Liu
+    "712020:798b9615-fcf0-4d2e-8830-24e0bf482a04": "rravaiol",             # Riccardo Ravaioli
+    "626b009fa32183006f2587ca":                    "sseethar",             # Surya Seetharaman
+    "712020:b3d7a67e-6fe1-4aea-8a2f-733c0ccf302d": SDN_TEAM_BOT_ASSIGNEE, # sdn-team bot
+    "70121:4fef5383-e773-49b8-bc72-258f4db6ed69":  DEFAULT_JIRA_ASSIGNEE,  # Ben Bennett
+}
+
 # WARNING 2025: the jira ID for new hires seems to be always prefixed with "rh-ee-" now
 RH_DEVELOPERS = (
     # "asuryana",
@@ -367,7 +388,7 @@ def align_jira_with_open_github_issues(github_issues):
                 matching_jira_details[jira_story.key] = {
                     "is_open": jira_story_is_open,
                     "url": get_jira_issue_url(jira_story.key),
-                    "assignee": jira_story.fields.assignee.name,
+                    "assignee": ACCOUNT_ID_TO_USERNAME.get(jira_story.fields.assignee.accountId, jira_story.fields.assignee.accountId) if jira_story.fields.assignee else None,
                 }
                 found_matching_jira = True
 
@@ -780,9 +801,10 @@ def process_jira_bugs(bugs, developers, quick=False):
     external_assignee, external_assignee_mail = get_username_and_usermail_from_assignee(EXTERNAL_JIRA_ASSIGNEE)
 
     for bug in bugs:
-        assignee = bug.get_field("assignee").name if bug.get_field("assignee") else None
-        if not assignee:
+        assignee_field = bug.get_field("assignee")
+        if not assignee_field:
             continue
+        assignee = ACCOUNT_ID_TO_USERNAME.get(assignee_field.accountId, EXTERNAL_JIRA_ASSIGNEE)
         assignee_user, assignee_mail = get_username_and_usermail_from_assignee(assignee)
         # values for status: new, assigned, on_dev, post, on_qa, verified, modified,
         # release_pending, closed

--- a/jira-scripts/network_bugs_overview
+++ b/jira-scripts/network_bugs_overview
@@ -581,7 +581,17 @@ def init_queries(clients, jira_bugs=True, jira_escalations=False):
 
 
 def init_jira():
-    return JIRA(options={"server": "https://redhat.atlassian.net", "rest_api_version": "3"}, basic_auth=(secrets["email"], secrets["token"]))
+    jira_client = JIRA(options={"server": "https://redhat.atlassian.net", "rest_api_version": "3"}, basic_auth=(secrets["email"], secrets["token"]))
+    # Verify authentication works - the search endpoint returns 200 even
+    # with invalid credentials (just hides private bugs), so check /myself
+    try:
+        url = jira_client._get_url('myself')
+        r = jira_client._session.get(url)
+    except Exception as ex:
+        sys.exit(f"Jira API token authentication failed. Generate a new token at "
+                 f"https://id.atlassian.com/manage-profile/security/api-tokens\n"
+                 f"Error: {ex}")
+    return jira_client
 
 
 def init_clients(jira_=True):

--- a/jira-scripts/network_bugs_overview
+++ b/jira-scripts/network_bugs_overview
@@ -29,36 +29,36 @@ SDN_TEAM_BOT_ASSIGNEE = "sdn-team-bot"
 # Jira Cloud uses accountId instead of username. This mapping translates
 # accountId -> RH_DEVELOPERS username so we can still key developers by email.
 ACCOUNT_ID_TO_USERNAME = {
-    "70121:0fad7649-85f6-49ed-a247-7d7641862d42": "rhn-support-arghosh",   # Arnab Ghosh
-    "712020:892d7637-f1cd-4db8-987f-1f0d225cc88c": "rh-ee-arsen",          # Arkadeep Sen
-    "712020:61bf71fd-6ba7-45de-98b4-3b34bb510754": "rh-ee-mapower",        # Marty Power
+    "70121:0fad7649-85f6-49ed-a247-7d7641862d42":  "arghosh",              # Arnab Ghosh
+    "712020:892d7637-f1cd-4db8-987f-1f0d225cc88c": "arsen",                # Arkadeep Sen
+    "712020:61bf71fd-6ba7-45de-98b4-3b34bb510754": "mapower",              # Marty Power
     "712020:5b2f5683-e0c3-4e7d-8a6a-6b844a91af04": "jcaamano",             # Jaime Caamano
     "712020:b94122c9-36dc-4439-a554-3b2f0a115212": "jluhrsen",             # Jamo Luhrsen
-    "712020:9b800968-bef3-40de-98dd-c2e19c216c28": "rh-ee-ljouin",         # Lionel Jouin
-    "712020:8b6d2da9-7640-4f54-bdd0-30d80e452597": "rh-ee-mdallagl",       # Matteo Dallaglio
-    "70121:1c35a408-cf23-4145-9827-b1cc93cbd64f": "rhn-support-misalunk",  # Miheer Salunke
-    "626ba32ce2f47a00682fbfc0":                    "mkennell",              # Martin Kennelly
+    "712020:9b800968-bef3-40de-98dd-c2e19c216c28": "ljouin",               # Lionel Jouin
+    "712020:8b6d2da9-7640-4f54-bdd0-30d80e452597": "mdallagl",             # Matteo Dallaglio
+    "70121:1c35a408-cf23-4145-9827-b1cc93cbd64f":  "misalunk",             # Miheer Salunke
+    "626ba32ce2f47a00682fbfc0":                    "mkennell",             # Martin Kennelly
     "712020:7d812864-56db-4370-ac8b-78d97167ff6a": "pdiak",                # Patryk Diak
     "712020:dbfcf885-e73f-4f5b-ab55-4d78a352993e": "pepalani",             # Periyasamy Palanisamy
     "5c6e1f975b4c2675327432d4":                    "pliurh",               # Peng Liu
     "712020:798b9615-fcf0-4d2e-8830-24e0bf482a04": "rravaiol",             # Riccardo Ravaioli
     "626b009fa32183006f2587ca":                    "sseethar",             # Surya Seetharaman
-    "712020:b3d7a67e-6fe1-4aea-8a2f-733c0ccf302d": SDN_TEAM_BOT_ASSIGNEE, # sdn-team bot
+    "712020:b3d7a67e-6fe1-4aea-8a2f-733c0ccf302d": SDN_TEAM_BOT_ASSIGNEE,  # sdn-team bot
     "70121:4fef5383-e773-49b8-bc72-258f4db6ed69":  DEFAULT_JIRA_ASSIGNEE,  # Ben Bennett
 }
 
 # WARNING 2025: the jira ID for new hires seems to be always prefixed with "rh-ee-" now
 RH_DEVELOPERS = (
     # "asuryana",
-    "rhn-support-arghosh",
-    "rh-ee-arsen",
-    "rh-ee-mapower",
+    "arghosh",
+    "arsen",
+    "mapower",
     "jcaamano",
     "jluhrsen",
     # "jtanenba",
-    "rh-ee-ljouin",
-    "rh-ee-mdallagl",
-    "rhn-support-misalunk",
+    "ljouin",
+    "mdallagl",
+    "misalunk",
     "mkennell",
     "pdiak",
     "pepalani",
@@ -72,17 +72,17 @@ RH_DEVELOPERS = (
 )
 
 GITHUB_TO_JIRA_USERS = {
-    "arghosh93": "rhn-support-arghosh",
-    "arkadeepsen": "rh-ee-arsen",
+    "arghosh93": "arghosh",
+    "arkadeepsen": "arsen",
     # "aswinsuryan": "asuryana",
-    "marty-power": "rh-ee-mapower",
+    "marty-power": "mapower",
     "jcaamano": "jcaamano",
     "jluhrsen": "jluhrsen",
     # "JacobTanenbaum": "jtanenba",
-    "LionelJouin":"rh-ee-ljouin",
+    "LionelJouin":"ljouin",
     "martinkennelly": "mkennell",
-    "mattedallo": "rh-ee-mdallagl",
-    "miheer": "rhn-support-misalunk",
+    "mattedallo": "mdallagl",
+    "miheer": "misalunk",
     "kyrtapz": "pdiak",
     "pperiyasamy": "pepalani",
     "pliurh": "pliurh",

--- a/jira-scripts/requirements.txt
+++ b/jira-scripts/requirements.txt
@@ -1,4 +1,4 @@
-jira
+jira>=3.0.0
 python-bugzilla
 python-dateutil
 tabulate


### PR DESCRIPTION
The cloud migration renamed the px score custom field and it can now be empty since the bots are not populating it yet.

Cloud uses ids to identify users not email addresses.  Changed the code to accommodate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved assignee handling and mapping accuracy for Jira stories.
  * Enhanced PX-score field extraction with better error handling.

* **Chores**
  * Migrated Jira instance URL to new infrastructure.
  * Updated Jira library dependency to version 3.0.0 or later.
  * Switched to updated Jira API format for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->