### PR TITLE
NO-JIRA: Refresh list of team members

### DIFF
--- a/jira-scripts/network_bugs_overview
+++ b/jira-scripts/network_bugs_overview
@@ -43,6 +43,7 @@ ACCOUNT_ID_TO_USERNAME = {
     "626b009fa32183006f2587ca":                    "sseethar",             # Surya Seetharaman
     "712020:d16c453d-e3cf-4796-aebb-a70394b1d715": "tasing",               # Tanya Singh
     "712020:e8f1060c-5b95-413b-8e1d-8d2bd5d1d472": "shbehera",             # Shreyas Behera
+    "712020:264e7000-6293-4c58-b0c2-35a605bebb9f": "raprosa",              # Raphael Rosa
     "712020:b3d7a67e-6fe1-4aea-8a2f-733c0ccf302d": SDN_TEAM_BOT_ASSIGNEE,  # sdn-team bot
     "712020:1212e771-04ed-4290-b4cd-906bad29a20e": DEFAULT_JIRA_ASSIGNEE,  # core-networking-bot
 }
@@ -66,6 +67,7 @@ RH_DEVELOPERS = (
     "sseethar",
     "tasing",
     "shbehera",
+    "raprosa",
     # "tpanteli",
     # "yboaron",
     EXTERNAL_JIRA_ASSIGNEE,  # placeholder for bugs in our components owned by external memebers
@@ -91,6 +93,7 @@ GITHUB_TO_JIRA_USERS = {
     "tssurya": "sseethar",
     "taanyas": "tasing",
     "shreyasbe": "shbehera",
+    "raphaelvrosa": "raprosa",
     # "yboaron": "yboaron",
 }
 
@@ -532,9 +535,9 @@ def retrieve_unassigned_jira_bugs():
     clients = init_clients(jira_=True)
     SDN_OCPBUGS_FILTER = 'project = OCPBUGS AND component in ("Networking / openshift-sdn", "Networking / ovn-kubernetes", "Networking / cloud-network-config-controller", "Networking / ingress-node-firewall", "Networking / cluster-network-operator", "Networking / network-tools")'
     query = (
-        f'(({SDN_OCPBUGS_FILTER}) OR project = RHOCPPRIO AND component in ("networking/sdn") '
-        "OR project = CORENET AND issuetype = Bug) AND resolution = Unresolved AND ((project = OCPBUGSM OR project = "
-        'OCPBUGS) AND assignee = "core-networking-bot@redhat.com" OR project = RHOCPPRIO AND assignee in ('
+        f'(({SDN_OCPBUGS_FILTER}) OR project = RHOCPPRIO AND component in ("networking/sdn")) '
+        " AND resolution = Unresolved AND ((project = OCPBUGSM OR project = "
+        'OCPBUGS) AND assignee in("core-networking-bot@redhat.com","bbennett@redhat.com") OR project = RHOCPPRIO AND assignee in ('
         '"anbhat@redhat.com", "zshi@redhat.com") OR assignee is EMPTY) ORDER BY Rank DESC'
     )
     bugs = run_jira_query(clients[JIRA_KEY], query)

--- a/jira-scripts/network_bugs_overview
+++ b/jira-scripts/network_bugs_overview
@@ -22,7 +22,7 @@ class colors:
 
 JIRA_EPIC_FOR_GITHUB_ISSUES = "CORENET-3945"
 GITHUB_ISSUES_LABEL = "kind/ci-flake"
-DEFAULT_JIRA_ASSIGNEE = "bbennett"
+DEFAULT_JIRA_ASSIGNEE = "core-networking-bot"
 EXTERNAL_JIRA_ASSIGNEE = "external" # placeholder for all assignees not in the team list
 SDN_TEAM_BOT_ASSIGNEE = "sdn-team-bot"
 
@@ -40,11 +40,11 @@ ACCOUNT_ID_TO_USERNAME = {
     "626ba32ce2f47a00682fbfc0":                    "mkennell",             # Martin Kennelly
     "712020:7d812864-56db-4370-ac8b-78d97167ff6a": "pdiak",                # Patryk Diak
     "712020:dbfcf885-e73f-4f5b-ab55-4d78a352993e": "pepalani",             # Periyasamy Palanisamy
-    "5c6e1f975b4c2675327432d4":                    "pliurh",               # Peng Liu
-    "712020:798b9615-fcf0-4d2e-8830-24e0bf482a04": "rravaiol",             # Riccardo Ravaioli
     "626b009fa32183006f2587ca":                    "sseethar",             # Surya Seetharaman
+    "712020:d16c453d-e3cf-4796-aebb-a70394b1d715": "tasing",               # Tanya Singh
+    "712020:e8f1060c-5b95-413b-8e1d-8d2bd5d1d472": "shbehera",             # Shreyas Behera
     "712020:b3d7a67e-6fe1-4aea-8a2f-733c0ccf302d": SDN_TEAM_BOT_ASSIGNEE,  # sdn-team bot
-    "70121:4fef5383-e773-49b8-bc72-258f4db6ed69":  DEFAULT_JIRA_ASSIGNEE,  # Ben Bennett
+    "712020:1212e771-04ed-4290-b4cd-906bad29a20e": DEFAULT_JIRA_ASSIGNEE,  # core-networking-bot
 }
 USERNAME_TO_ACCOUNT_ID = {v: k for k, v in ACCOUNT_ID_TO_USERNAME.items()}
 
@@ -63,13 +63,14 @@ RH_DEVELOPERS = (
     "mkennell",
     "pdiak",
     "pepalani",
-    "pliurh",
-    "rravaiol",
     "sseethar",
+    "tasing",
+    "shbehera",
     # "tpanteli",
     # "yboaron",
     EXTERNAL_JIRA_ASSIGNEE,  # placeholder for bugs in our components owned by external memebers
-    SDN_TEAM_BOT_ASSIGNEE, # special user acting as our team backlog
+    SDN_TEAM_BOT_ASSIGNEE,   # special user acting as our team backlog
+    DEFAULT_JIRA_ASSIGNEE,   # special user acting as our team default assignee
 )
 
 GITHUB_TO_JIRA_USERS = {
@@ -86,10 +87,10 @@ GITHUB_TO_JIRA_USERS = {
     "miheer": "misalunk",
     "kyrtapz": "pdiak",
     "pperiyasamy": "pepalani",
-    "pliurh": "pliurh",
-    "ricky-rav": "rravaiol",
     # "tpantelis": "tpanteli",
     "tssurya": "sseethar",
+    "taanyas": "tasing",
+    "shreyasbe": "shbehera",
     # "yboaron": "yboaron",
 }
 
@@ -533,7 +534,7 @@ def retrieve_unassigned_jira_bugs():
     query = (
         f'(({SDN_OCPBUGS_FILTER}) OR project = RHOCPPRIO AND component in ("networking/sdn") '
         "OR project = CORENET AND issuetype = Bug) AND resolution = Unresolved AND ((project = OCPBUGSM OR project = "
-        'OCPBUGS) AND assignee = "bbennett@redhat.com" OR project = RHOCPPRIO AND assignee in ('
+        'OCPBUGS) AND assignee = "core-networking-bot@redhat.com" OR project = RHOCPPRIO AND assignee in ('
         '"anbhat@redhat.com", "zshi@redhat.com") OR assignee is EMPTY) ORDER BY Rank DESC'
     )
     bugs = run_jira_query(clients[JIRA_KEY], query)
@@ -816,7 +817,7 @@ def was_jira_bug_recently_assigned(bug):
 def process_jira_bugs(bugs, developers, quick=False):
     # bugs that have been in new state for more than 30 days (arbitary time window)
     stale_bugs = {}
-    default_assignee, default_assignee_mail = get_username_and_usermail_from_assignee(DEFAULT_JIRA_ASSIGNEE)  # bbennett
+    default_assignee, default_assignee_mail = get_username_and_usermail_from_assignee(DEFAULT_JIRA_ASSIGNEE)  # core-networking-bot
     external_assignee, external_assignee_mail = get_username_and_usermail_from_assignee(EXTERNAL_JIRA_ASSIGNEE)
 
     for bug in bugs:
@@ -840,7 +841,7 @@ def process_jira_bugs(bugs, developers, quick=False):
         # an assignee in jira bugs is very often a developer's official email address, but
         # it might also be just a username.
         if assignee_mail not in developers:
-            # skip if it's assigned to bbennett
+            # skip if it's assigned to default assignee
             if assignee_mail == default_assignee_mail:
                 continue
 
@@ -1049,6 +1050,7 @@ def print_summary_table(developers, quick=False):
     # Remove external devs from the count
     _, external_assignee_mail = get_username_and_usermail_from_assignee(EXTERNAL_JIRA_ASSIGNEE)
     _, sdn_team_bot_assignee_mail = get_username_and_usermail_from_assignee(SDN_TEAM_BOT_ASSIGNEE)
+    _, core_networking_bot_assignee_mail = get_username_and_usermail_from_assignee(DEFAULT_JIRA_ASSIGNEE)
 
     external_data = []
     if external_assignee_mail in developers:
@@ -1057,6 +1059,10 @@ def print_summary_table(developers, quick=False):
     sdn_team_bot_data = []
     if sdn_team_bot_assignee_mail in developers:
         sdn_team_bot_data = developers.pop(sdn_team_bot_assignee_mail)
+
+    core_networking_bot_data = []
+    if core_networking_bot_assignee_mail in developers:
+        core_networking_bot_data = developers.pop(core_networking_bot_assignee_mail)
 
     # Sorting the list by points field
     ordered_by_points = collections.OrderedDict(
@@ -1098,7 +1104,7 @@ def print_summary_table(developers, quick=False):
 
     lines.append(SEPARATING_LINE)
 
-    # add summary lines (total bugs for the team, for external team members, for sdn team bot)
+    # add summary lines (total bugs for the team and special assignees)
     num = sum(ordered_by_points[dev]["number_of_bugs"] for dev in ordered_by_points)
     num_new = sum(ordered_by_points[dev]["bugs_in_new"] for dev in ordered_by_points)
     num_assigned = sum(ordered_by_points[dev]["bugs_in_assigned"] for dev in ordered_by_points)
@@ -1113,13 +1119,14 @@ def print_summary_table(developers, quick=False):
 
     external_line = prepare_extra_line(external_data, "external", quick=quick)
     bot_line = prepare_extra_line(sdn_team_bot_data, "sdn-team-bot", quick=quick)
+    core_networking_bot_line = prepare_extra_line(core_networking_bot_data, DEFAULT_JIRA_ASSIGNEE, quick=quick)
 
-    # add total line (team + external + bot)
+    # add total line (team + external + special assignees)
     total_line = ["", "TOTAL", None]
     for i in range(3, len(team_line)):
-        if i < len(external_line) and i < len(bot_line):
+        if i < len(external_line) and i < len(bot_line) and i < len(core_networking_bot_line):
             try:
-                total_val = team_line[i] + external_line[i] + bot_line[i]
+                total_val = team_line[i] + external_line[i] + bot_line[i] + core_networking_bot_line[i]
             except:
                 # not an int, just add a blank
                 total_val = None
@@ -1129,6 +1136,7 @@ def print_summary_table(developers, quick=False):
     lines.append(team_line)
     lines.append(external_line)
     lines.append(bot_line)
+    lines.append(core_networking_bot_line)
     lines.append(SEPARATING_LINE)
     lines.append(total_line)
 


### PR DESCRIPTION
Refresh members list, and replace bbennett with
core-networking-bot as the new default assignee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Changed the default Jira assignee to core-networking-bot and updated unassigned-bug and workload assignment logic accordingly.
  * Updated team/developer allowlist to add sseethar, tasing, shbehera, raprosa and removed deprecated entries.
  * Refreshed account and GitHub-to-Jira user mappings to reflect current team mappings and removed outdated mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->