### PR TITLE
The subcommand network-test was not working due to /sbin/init command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN rm -rf /opt/bin/local-scripts && ln -s /opt/bin/network-tools /usr/bin/netwo
 RUN INSTALL_PKGS="\
     conntrack-tools \
     iproute \
-    nginx \
     numactl \
     traceroute \
     wireshark-cli \

--- a/Dockerfile.fedora
+++ b/Dockerfile.fedora
@@ -5,9 +5,9 @@
 # This image is only for development environment, so please DO NOT DEPLOY
 # this image in any production environment.
 #
-FROM registry.ci.openshift.org/ocp/4.12:ovn-kubernetes AS ovnkube-trace
+FROM registry.ci.openshift.org/ocp/4.22:ovn-kubernetes AS ovnkube-trace
 
-FROM registry.ci.openshift.org/ocp/4.12:tools AS tools
+FROM registry.ci.openshift.org/ocp/4.22:tools AS tools
 
 FROM fedora:latest
 COPY --from=ovnkube-trace /usr/bin/ovnkube-trace /usr/bin/
@@ -41,7 +41,6 @@ RUN INSTALL_PKGS="\
     ltrace \
     mailx \
     net-tools \
-    nginx \
     nmap-ncat \
     numactl \
     parted \
@@ -62,8 +61,8 @@ RUN INSTALL_PKGS="\
     wireshark-cli \
     xfsprogs \
     " && \
-    yum -y install --setopt=tsflags=nodocs --setopt=skip_missing_names_on_install=False $INSTALL_PKGS && \
-    yum clean all && rm -rf /var/cache/*
+    dnf -y install --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    dnf clean all && rm -rf /var/cache/*
 
 COPY debug-scripts/ /opt/bin/
 # remove internal scripts from the image and create a symlink for network-tools and gather entrypoint for must-gather

--- a/debug-scripts/test-networking/common
+++ b/debug-scripts/test-networking/common
@@ -16,7 +16,7 @@ create_pod_on_node () {
 
     oc run "$POD_NAME" --image=quay.io/openshift/origin-network-tools:latest \
         --overrides='{ "spec": { "nodeSelector": {"'"$POD_NAME"'": "network-tools-debug-role"}, "tolerations": [{"key": "node-role.kubernetes.io/master", "effect": "NoSchedule", "operator": "Exists"}] }}' \
-        -- /sbin/init
+        -- python3 -m http.server 80
 
     # wait till pod is running
     oc wait --for=condition=Ready pod/"$POD_NAME" --timeout=3m
@@ -31,8 +31,7 @@ create_svc () {
     # create the backing pod
     create_pod_on_node "$SVC_NAME" "$NODE_NAME"
     echo "INFO: Creating a ClusterIP service: "$SVC_NAME""
-    # start webserver and expose the port
-    oc rsh "$SVC_NAME" systemctl start nginx
+
     # TODO: Allow users to specify which svc type they want to test
     oc expose pod/"$SVC_NAME" --port=80
     # wait till svc endpoint is created

--- a/docs/user.md
+++ b/docs/user.md
@@ -60,7 +60,6 @@ To run script that are not included in the `network-tools -h` call them directly
 * bcc
 * bcc-tools
 * python3-bcc
-* nginx
 * numactl
 * traceroute
 * wireshark-cli


### PR DESCRIPTION
  - systemd container was only needed for nginx server which can be replaced with python http server
  - For network tests changing all pods created by script to run python server by default
  - Remove nginx package from Dockerfile and Dockerfile.fedora as its not needed for testing network
  - Made changes to Dockerfile.fedora updating to 4.22 build and changing yum to dnf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced debugging tools available in the network-tools image, including additional utilities for network analysis and performance troubleshooting.

* **Bug Fixes**
  * Removed nginx from container images and debug pod initialization to streamline network debugging workflows.

* **Documentation**
  * Updated documentation to reflect the available debugging utilities in the network-tools image.

* **Chores**
  * Updated base image versions to latest available releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->