### PR TITLE
Filter out dummy bugs from bug counts

### DIFF
--- a/jira-scripts/network_bugs_overview
+++ b/jira-scripts/network_bugs_overview
@@ -851,6 +851,9 @@ def process_jira_bugs(bugs, developers, quick=False):
         bug_id = str(bug.key)
         creation_time = bug.get_field("created")
         summary = bug.get_field("summary")
+        # skip dummy bugs
+        if summary and "(dummy bug)" in summary.lower():
+            continue
         components = [c.name.lower() for c in bug.get_field("components")]
         fix_versions = [
             v.name for v in bug.get_field("fixVersions")


### PR DESCRIPTION
Skip bugs with "(dummy bug)" in the summary when calculating developer workloads and team statistics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dummy Jira bugs are now excluded from bug statistics and attribution.
  * Issues marked as “(dummy bug)” in their summary are skipped automatically, preventing them from affecting reported counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->