### PR TITLE
Adds hping3 and netcat to install pkgs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,22 @@ COPY --from=ovnkube-trace /usr/bin/ovnkube-trace /usr/bin/
 RUN rm -rf /opt/bin/local-scripts && ln -s /opt/bin/network-tools /usr/bin/network-tools && ln -s /opt/bin/network-tools /usr/bin/gather
 
 
+# Install EPEL repository for hping3
+RUN curl --fail --show-error -L https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/e/epel-release-9-11.el9.noarch.rpm -o /tmp/epel.rpm && \
+    echo "b434245bffd8b40ea486157e72363d08b36e38145c8f917c5c00adfca3f2101b  /tmp/epel.rpm" | sha256sum -c - && \
+    rpm -ivh /tmp/epel.rpm && \
+    rm -f /tmp/epel.rpm
+
 # Make sure to maintain alphabetical ordering when adding new packages.
+# hping3 is available in EPEL (Extra Packages for Enterprise Linux)
 RUN INSTALL_PKGS="\
     conntrack-tools \
+    hping3 \
     iproute \
+    nmap-ncat \
     nginx \
     numactl \
+    tcl \
     traceroute \
     wireshark-cli \
     " && \

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ IMAGE_REGISTRY := registry.ci.openshift.org
 # $2 - image ref
 # $3 - Dockerfile path
 # $4 - context directory for image build
-$(call build-image,ocp-network-tools,$(IMAGE_REGISTRY)/ocp/4.7:ocp-network-tools, ./Dockerfile,.)
+$(call build-image,ocp-network-tools,$(IMAGE_REGISTRY)/ocp/5.0:ocp-network-tools, ./Dockerfile,.)
 
 # The "rhel" Dockerfile requires fiddling with RHEL subscriptions.
 # For testing purposes it's easier to just build a fedora-based image


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the bundled network diagnostics toolset used for connectivity testing and troubleshooting, adding support for additional tools such as `hping3` and `nmap-ncat`.
* **Chores**
  * Updated the `ocp-network-tools` container image build to target the newer release line (`5.0`), keeping the rest of the build process the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->